### PR TITLE
Feature: timing

### DIFF
--- a/build/Makefile.conf.ifort
+++ b/build/Makefile.conf.ifort
@@ -13,5 +13,5 @@ export F77FLAGS = -m64 -O3 -traceback                                        -qo
 #
 # Debugging
 #
-export FCFLAGS  = -m64 -g  -traceback -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f03
-export F77FLAGS = -m64 -g  -traceback                                        -check bounds,uninit,pointers,stack
+# export FCFLAGS  = -m64 -g  -traceback -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f03
+# export F77FLAGS = -m64 -g  -traceback                                        -check bounds,uninit,pointers,stack

--- a/build/Makefile.conf.ifort
+++ b/build/Makefile.conf.ifort
@@ -13,5 +13,5 @@ export F77FLAGS = -m64 -O3 -traceback                                        -qo
 #
 # Debugging
 #
-# export FCFLAGS  = -m64 -g  -traceback -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f03
-# export F77FLAGS = -m64 -g  -traceback                                        -check bounds,uninit,pointers,stack
+export FCFLAGS  = -m64 -g  -traceback -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f03
+export F77FLAGS = -m64 -g  -traceback                                        -check bounds,uninit,pointers,stack

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -8,6 +8,13 @@ include $(RRTMGP_DIR)/Makefile.conf
 LDFLAGS   += -L$(RRTMGP_DIR)
 LIBS      += -lrrtmgp -lrte
 FCINCLUDE += -I$(RRTMGP_DIR)
+#
+# Timing library
+#
+TIME_DIR = /Users/robert/Codes/GPTL/gptl-v5.5.3/macos
+LDFLAGS   += -L$(TIME_DIR)/lib
+LIBS      += -lgptl
+FCINCLUDE += -I$(TIME_DIR)/include
 
 #
 # netcdf library, module files

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -9,20 +9,6 @@ LDFLAGS   += -L$(RRTMGP_DIR)
 LIBS      += -lrrtmgp -lrte
 FCINCLUDE += -I$(RRTMGP_DIR)
 
-TIMING=no
-ifeq ($(TIMING),yes)
-	#
-	# Timing library
-	#
-	FCINCLUDE += -I$(TIME_DIR)/include
-	# Compiler specific
-	FCFLAGS += -fpp -DUSE_TIMING
-	TIME_DIR = $(HOME)/Codes/GPTL/gptl-v5.5.3/macos
-	LDFLAGS   += -L$(TIME_DIR)/lib
-	LIBS      += -lgptl
-endif
-
-
 #
 # netcdf library, module files
 # C and Fortran interfaces respectively
@@ -33,6 +19,26 @@ FCINCLUDE += -I$(NFHOME)/include
 LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
 LIBS      += -lnetcdff -lnetcdf
 
+#
+# Setting macro TIMING=yes uses routines from the General Purpose Timing Library
+#  https://jmrosinski.github.io/GPTL/
+#
+TIMING=no
+# Compiler specific - e.g. turn off for pgfortran, set to -cpp for gfortran
+FCFLAGS += -fpp
+ifeq ($(TIMING),yes)
+	#
+	# Timing library
+	#
+	FCINCLUDE += -I$(TIME_DIR)/include
+	# Compiler specific
+	FCFLAGS += -DUSE_TIMING
+	# Installation specific
+	TIME_DIR = $(HOME)/Codes/GPTL/gptl-v5.5.3/macos
+	LDFLAGS   += -L$(TIME_DIR)/lib
+	LIBS      += -lgptl
+endif
+
 VPATH = ../
 
 # Compilation rules
@@ -41,7 +47,6 @@ VPATH = ../
 
 %: %.o
 	$(FC) $(FCFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
-
 
 #
 # Ancillary codes

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -8,20 +8,27 @@ include $(RRTMGP_DIR)/Makefile.conf
 LDFLAGS   += -L$(RRTMGP_DIR)
 LIBS      += -lrrtmgp -lrte
 FCINCLUDE += -I$(RRTMGP_DIR)
-#
-# Timing library
-#
-TIME_DIR = /Users/robert/Codes/GPTL/gptl-v5.5.3/macos
-LDFLAGS   += -L$(TIME_DIR)/lib
-LIBS      += -lgptl
-FCINCLUDE += -I$(TIME_DIR)/include
+
+TIMING=no
+ifeq ($(TIMING),yes)
+	#
+	# Timing library
+	#
+	FCINCLUDE += -I$(TIME_DIR)/include
+	# Compiler specific
+	FCFLAGS += -fpp -DUSE_TIMING
+	TIME_DIR = $(HOME)/Codes/GPTL/gptl-v5.5.3/macos
+	LDFLAGS   += -L$(TIME_DIR)/lib
+	LIBS      += -lgptl
+endif
+
 
 #
 # netcdf library, module files
 # C and Fortran interfaces respectively
 #
 NCHOME = /opt/local
-NFHOME = /Users/robert/Applications/$(FC)
+NFHOME = $(HOME)/Applications/$(FC)
 FCINCLUDE += -I$(NFHOME)/include
 LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
 LIBS      += -lnetcdff -lnetcdf

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
@@ -84,7 +84,8 @@ program rrtmgp_rfmip_lw
   !
   ! Timing library
   !
-  use gptl,                  only: gptlstart, gptlstop, gptlinitialize, gptlpr, gptlfinalize
+  use gptl,                  only: gptlstart, gptlstop, gptlinitialize, gptlpr, gptlfinalize, gptlsetoption, &
+                                   gptlpercent, gptloverhead
   implicit none
   ! --------------------------------------------------
   !
@@ -209,6 +210,8 @@ program rrtmgp_rfmip_lw
   !
   ! Initialize timers
   !
+  ret = gptlsetoption (gptlpercent, 1)        ! Turn on "% of" print
+  ret = gptlsetoption (gptloverhead, 0)       ! Turn off overhead estimate
   ret =  gptlinitialize()
   !
   ! Loop over blocks

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
@@ -84,7 +84,7 @@ program rrtmgp_rfmip_lw
   !
   ! Timing library
   !
-  use gptl,              only: gptlstart, gptlstop, gptlinitialize, gptlpr, gptlfinalize
+  use gptl,                  only: gptlstart, gptlstop, gptlinitialize, gptlpr, gptlfinalize
   implicit none
   ! --------------------------------------------------
   !
@@ -220,7 +220,7 @@ program rrtmgp_rfmip_lw
     ! Compute the optical properties of the atmosphere and the Planck source functions
     !    from pressures, temperatures, and gas concentrations...
     !
-    ret =  gptlstart('gas_optics')
+    ret =  gptlstart('gas_optics (LW)')
     call stop_on_err(k_dist%gas_optics(p_lay(:,:,b), &
                                        p_lev(:,:,b),       &
                                        t_lay(:,:,b),       &
@@ -229,7 +229,7 @@ program rrtmgp_rfmip_lw
                                        optical_props,      &
                                        source,             &
                                        tlev = t_lev(:,:,b)))
-    ret =  gptlstop('gas_optics')
+    ret =  gptlstop('gas_optics (LW)')
     !
     ! ... and compute the spectrally-resolved fluxes, providing reduced values
     !    via ty_fluxes_broadband

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
@@ -240,7 +240,7 @@ program rrtmgp_rfmip_sw
     !
     ! Normalize incoming solar flux to match RFMIP specification
     !
-    def_tsi(1:ncol) = sum(toa_flux, dim=2)
+    def_tsi(1:block_size) = sum(toa_flux, dim=2)
     do igpt = 1, k_dist%get_ngpt()
       do icol = 1, block_size
         toa_flux(icol,igpt) = toa_flux(icol,igpt) * total_solar_irradiance(icol,b)/def_tsi(icol)

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
@@ -80,7 +80,8 @@ program rrtmgp_rfmip_sw
   !
   ! Timing library
   !
-  use gptl,                   only: gptlstart, gptlstop, gptlinitialize, gptlpr, gptlfinalize
+  use gptl,                  only: gptlstart, gptlstop, gptlinitialize, gptlpr, gptlfinalize, gptlsetoption, &
+                                   gptlpercent, gptloverhead
   implicit none
   ! --------------------------------------------------
   !
@@ -207,6 +208,8 @@ program rrtmgp_rfmip_sw
   !
   ! Initialize timers
   !
+  ret = gptlsetoption (gptlpercent, 1)        ! Turn on "% of" print
+  ret = gptlsetoption (gptloverhead, 0)       ! Turn off overhead estimate
   ret =  gptlinitialize()
   !
   ! Loop over blocks
@@ -246,7 +249,7 @@ program rrtmgp_rfmip_sw
     ! ... and compute the spectrally-resolved fluxes, providing reduced values
     !    via ty_fluxes_broadband
     !
-    ret =  gptlstart('rte_lw')
+    ret =  gptlstart('rte_sw')
     call stop_on_err(rte_sw(optical_props,   &
                             top_at_1,        &
                             solar_zenith_angle(:,b), &
@@ -254,7 +257,7 @@ program rrtmgp_rfmip_sw
                             spread(surface_albedo(:,b), 1, ncopies = k_dist%get_nband()), &
                             spread(surface_albedo(:,b), 1, ncopies = k_dist%get_nband()), &
                             fluxes))
-    ret =  gptlstop('rte_lw')
+    ret =  gptlstop('rte_sw')
     !
     ! Zero out fluxes for which the original solar zenith angle is <= 0.
     !


### PR DESCRIPTION
Adding optional General Purpose Timing Library (https://jmrosinski.github.io/GPTL/) routines to RFMIP SW and LW drivers,  set with a macro in examples/rfmip-clear-sky/Makefile. 