### PR TITLE
Adding shortwave driver for RFMIP; timing for both SW and LW RFMIP drivers. 

### DIFF
--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -34,15 +34,19 @@ VPATH = ../
 #
 ADDITIONS = mo_simple_netcdf.o mo_rfmip_io.o mo_load_coefficients.o
 
-all: rrtmgp_rfmip_lw
+all: rrtmgp_rfmip_lw rrtmgp_rfmip_sw
 
-rrtmgp_rfmip_lw: rrtmgp_rfmip_lw.o $(ADDITIONS)
+rrtmgp_rfmip_lw:   rrtmgp_rfmip_lw.o   $(ADDITIONS)
 
 rrtmgp_rfmip_lw.o: rrtmgp_rfmip_lw.F90 $(ADDITIONS)
 
-mo_rfmip_io.o:          mo_simple_netcdf.o mo_rfmip_io.F90           
+rrtmgp_rfmip_sw:   rrtmgp_rfmip_sw.o   $(ADDITIONS)
 
-mo_load_coefficients.o: mo_simple_netcdf.o mo_load_coefficients.F90
+rrtmgp_rfmip_sw.o: rrtmgp_rfmip_sw.F90 $(ADDITIONS)
+
+mo_rfmip_io.o:          mo_rfmip_io.F90          mo_simple_netcdf.o
+
+mo_load_coefficients.o: mo_load_coefficients.F90 mo_simple_netcdf.o
 
 clean:
 	-rm rrtmgp_rfmip_lw *.o *.mod *.optrpt ../*.optrpt

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -14,10 +14,30 @@ FCINCLUDE += -I$(RRTMGP_DIR)
 # C and Fortran interfaces respectively
 #
 NCHOME = /opt/local
-NFHOME = /Users/robert/Applications/$(FC)
+NFHOME = $(HOME)/Applications/$(FC)
 FCINCLUDE += -I$(NFHOME)/include
 LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
 LIBS      += -lnetcdff -lnetcdf
+
+#
+# Setting macro TIMING=yes uses routines from the General Purpose Timing Library
+#  https://jmrosinski.github.io/GPTL/
+#
+TIMING=no
+# Compiler specific - e.g. turn off for pgfortran, set to -cpp for gfortran
+FCFLAGS += -fpp
+ifeq ($(TIMING),yes)
+	#
+	# Timing library
+	#
+	FCINCLUDE += -I$(TIME_DIR)/include
+	# Compiler specific
+	FCFLAGS += -DUSE_TIMING
+	# Installation specific
+	TIME_DIR = $(HOME)/Codes/GPTL/gptl-v5.5.3/macos
+	LDFLAGS   += -L$(TIME_DIR)/lib
+	LIBS      += -lgptl
+endif
 
 VPATH = ../
 
@@ -27,7 +47,6 @@ VPATH = ../
 
 %: %.o
 	$(FC) $(FCFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
-
 
 #
 # Ancillary codes

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
@@ -81,6 +81,13 @@ program rrtmgp_rfmip_lw
   use mo_load_coefficients,  only: load_and_init
   use mo_rfmip_io,           only: read_size, read_and_block_pt, read_and_block_gases_ty, unblock_and_write, &
                                    read_and_block_lw_bc, read_kdist_gas_names
+#IFDEF USE_TIMING
+  !
+  ! Timing library
+  !
+  use gptl,                  only: gptlstart, gptlstop, gptlinitialize, gptlpr, gptlfinalize, gptlsetoption, &
+                                   gptlpercent, gptloverhead
+#ENDIF
   implicit none
   ! --------------------------------------------------
   !
@@ -112,6 +119,8 @@ program rrtmgp_rfmip_lw
   !   leverage what we know about the input file
   !
   type(ty_gas_concs), dimension(:), allocatable  :: gas_conc_array
+
+  integer :: ret
   ! -------------------------------------------------------------------------------------------------
   !
   ! Code starts
@@ -200,6 +209,14 @@ program rrtmgp_rfmip_lw
   call stop_on_err(source%alloc            (block_size, nlay, k_dist))
   call stop_on_err(optical_props%alloc_1scl(block_size, nlay, k_dist))
   ! --------------------------------------------------
+#IFDEF USE_TIMING
+  !
+  ! Initialize timers
+  !
+  ret = gptlsetoption (gptlpercent, 1)        ! Turn on "% of" print
+  ret = gptlsetoption (gptloverhead, 0)       ! Turn off overhead estimate
+  ret =  gptlinitialize()
+#ENDIF
   !
   ! Loop over blocks
   !
@@ -210,6 +227,9 @@ program rrtmgp_rfmip_lw
     ! Compute the optical properties of the atmosphere and the Planck source functions
     !    from pressures, temperatures, and gas concentrations...
     !
+#IFDEF USE_TIMING
+    ret =  gptlstart('gas_optics (LW)')
+#ENDIF
     call stop_on_err(k_dist%gas_optics(p_lay(:,:,b), &
                                        p_lev(:,:,b),       &
                                        t_lay(:,:,b),       &
@@ -218,16 +238,32 @@ program rrtmgp_rfmip_lw
                                        optical_props,      &
                                        source,             &
                                        tlev = t_lev(:,:,b)))
+#IFDEF USE_TIMING
+    ret =  gptlstop('gas_optics (LW)')
+#ENDIF
     !
     ! ... and compute the spectrally-resolved fluxes, providing reduced values
     !    via ty_fluxes_broadband
     !
+#IFDEF USE_TIMING
+    ret =  gptlstart('rte_lw')
+#ENDIF
     call stop_on_err(rte_lw(optical_props,   &
                             top_at_1,        &
                             source,          &
                             spread(sfc_emis(:,b), 1, ncopies = k_dist%get_nband()), &
                             fluxes))
+#IFDEF USE_TIMING
+    ret =  gptlstop('rte_lw')
+#ENDIF
   end do
+#IFDEF USE_TIMING
+  !
+  ! End timers
+  !
+  ret = gptlpr(block_size)
+  ret = gptlfinalize()
+#ENDIF
   ! --------------------------------------------------
   call unblock_and_write(trim(flxup_file), 'rlu', flux_up)
   call unblock_and_write(trim(flxdn_file), 'rld', flux_dn)

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
@@ -251,8 +251,8 @@ program rrtmgp_rfmip_sw
     !   nighttime columns with a default solar zenith angle. We'll mask these out later, of
     !   course, but this gives us more work and so a better measure of timing.
     !
-    usecol(1:block_size)  = solar_zenith_angle(:,b) < 90._wp - 2._wp * spacing(90._wp)
-    mu0(1:block_size) = merge(cos(solar_zenith_angle(:,b) * acos(-1._wp)/180._wp), 0._wp, usecol)
+    usecol(1:block_size)  = solar_zenith_angle(1:block_size,b) < 90._wp - 2._wp * spacing(90._wp)
+    mu0(1:block_size) = merge(cos(solar_zenith_angle(:,b) * acos(-1._wp)/180._wp), 1._wp, usecol)
     !
     ! ... and compute the spectrally-resolved fluxes, providing reduced values
     !    via ty_fluxes_broadband
@@ -262,8 +262,8 @@ program rrtmgp_rfmip_sw
 #ENDIF
     call stop_on_err(rte_sw(optical_props,   &
                             top_at_1,        &
-                            solar_zenith_angle(:,b), &
-                            toa_flux,         &
+                            mu0,             &
+                            toa_flux,        &
                             spread(surface_albedo(:,b), 1, ncopies = k_dist%get_nband()), &
                             spread(surface_albedo(:,b), 1, ncopies = k_dist%get_nband()), &
                             fluxes))

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
@@ -1,0 +1,257 @@
+! This code is part of RRTM for GCM Applications - Parallel (RRTMGP)
+!
+! Contacts: Robert Pincus and Eli Mlawer
+! email:  rrtmgp@aer.com
+!
+! Copyright 2015-2018,  Atmospheric and Environmental Research and
+! Regents of the University of Colorado.  All right reserved.
+!
+! Use and duplication is permitted under the terms of the
+!    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
+! -------------------------------------------------------------------------------------------------
+!
+! Example program to demonstrate the calculation of shortwave radiative fluxes in clear, aerosol-free skies.
+!   The example files come from the Radiative Forcing MIP (https://www.earthsystemcog.org/projects/rfmip/)
+!   The large problem (1800 profiles) is divided into blocks
+!
+! Program is invoked as rrtmgp_rfmip_sw [block_size input_file  coefficient_file upflux_file downflux_file]
+!   All arguments are optional but need to be specified in order.
+!
+! -------------------------------------------------------------------------------------------------
+!
+! Error checking: Procedures in rte+rrtmgp return strings which are empty if no errors occured
+!   Check the incoming string, print it out and stop execution if non-empty
+!
+subroutine stop_on_err(error_msg)
+  use iso_fortran_env, only : error_unit
+  character(len=*), intent(in) :: error_msg
+
+  if(error_msg /= "") then
+    write (error_unit,*) trim(error_msg)
+    write (error_unit,*) "rrtmgp_rfmip_sw stopping"
+    stop
+  end if
+end subroutine stop_on_err
+! -------------------------------------------------------------------------------------------------
+!
+! Main program
+!
+! -------------------------------------------------------------------------------------------------
+program rrtmgp_rfmip_sw
+  ! --------------------------------------------------
+  !
+  ! Modules for working with rte and rrtmgp
+  !
+  ! Working precision for real variables
+  !
+  use mo_rte_kind,           only: wp
+  !
+  ! Optical properties of the atmosphere as array of values
+  !   In the longwave we include only absorption optical depth (_1scl)
+  !   Shortwave calculations use optical depth, single-scattering albedo, asymmetry parameter (_2str)
+  !
+  use mo_optical_props,      only: ty_optical_props_2str
+  !
+  ! Gas optics: maps physical state of the atmosphere to optical properties
+  !
+  use mo_gas_optics,         only: ty_gas_optics
+  !
+  ! Gas optics uses a derived type to represent gas concentrations compactly
+  !
+  use mo_gas_concentrations, only: ty_gas_concs
+  !
+  ! RTE shortwave driver
+  !
+  use mo_rte_sw,             only: rte_sw
+  !
+  ! RTE driver uses a derived type to reduce spectral fluxes to whatever the user wants
+  !   Here we're just reporting broadband fluxes
+  !
+  use mo_fluxes,             only: ty_fluxes_broadband
+  ! --------------------------------------------------
+  !
+  ! modules for reading and writing files
+  !
+  ! RRTMGP's gas optics class needs to be initialized with data read from a netCDF files
+  !
+  use mo_load_coefficients,  only: load_and_init
+  use mo_rfmip_io,           only: read_size, read_and_block_pt, read_and_block_gases_ty, unblock_and_write, &
+                                   read_and_block_sw_bc, read_kdist_gas_names
+  implicit none
+  ! --------------------------------------------------
+  !
+  ! Local variables
+  !
+  character(len=132)         :: rfmip_file = 'multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-0-4_none.nc', &
+                                kdist_file = 'coefficients_sw.nc', &
+                                flxdn_file = 'rsd_template.nc', flxup_file = 'rsu_template.nc'
+  integer                    :: nargs, ncol, nlay, nexp, nblocks, block_size
+  logical                    :: top_at_1
+  integer                    :: b, icol, igpt
+  character(len=6)           :: block_size_char
+
+  character(len=32 ), &
+            dimension(:),             allocatable :: kdist_gas_names, gases_to_use
+  real(wp), dimension(:,:,:),         allocatable :: p_lay, p_lev, t_lay, t_lev ! block_size, nlay, nblocks
+  real(wp), dimension(:,:,:), target, allocatable :: flux_up, flux_dn
+  real(wp), dimension(:,:  ),         allocatable :: surface_albedo, total_solar_irradiance, solar_zenith_angle
+                                                     ! block_size, nblocks
+  !
+  ! Classes used by rte+rrtmgp
+  !
+  type(ty_gas_optics)                            :: k_dist
+  type(ty_optical_props_2str)                    :: optical_props
+  type(ty_fluxes_broadband)                      :: fluxes
+  real(wp), dimension(:,:), allocatable          :: toa_flux ! block_size, ngpt
+  real(wp), dimension(:  ), allocatable          :: def_tsi, mu0 ! block_size
+  logical , dimension(:  ), allocatable          :: usecol ! block_size, ngpt
+  !
+  ! ty_gas_concentration holds multiple columns; we make an array of these objects to
+  !   leverage what we know about the input file
+  !
+  type(ty_gas_concs), dimension(:), allocatable  :: gas_conc_array
+  ! -------------------------------------------------------------------------------------------------
+  !
+  ! Code starts
+  ! Argument list:
+  !   block size, input file, coefficient file, upflux file, downflux file
+  !   all arguments are optional
+  !
+  nargs = command_argument_count()
+  if(nargs >= 2) call get_command_argument(2, rfmip_file)
+  if(nargs >= 3) call get_command_argument(3, kdist_file)
+  if(nargs >= 4) call get_command_argument(4, flxup_file)
+  if(nargs >= 5) call get_command_argument(5, flxdn_file)
+
+  ! How big is the problem? Does it fit into blocks of the size we've specified?
+  !
+  call read_size(rfmip_file, ncol, nlay, nexp)
+  if(nargs >= 1) then
+    call get_command_argument(1, block_size_char)
+    read(block_size_char, '(i6)') block_size
+  else
+    block_size = ncol
+  end if
+  if(mod(ncol*nexp, block_size) /= 0 ) call stop_on_err("rrtmgp_rfmip_sw: number of columns doesn't fit evenly into blocks.")
+  nblocks = (ncol*nexp)/block_size
+  print *, "Doing ",  nblocks, "blocks of size ", block_size
+
+  !
+  ! Names of gases known to the k-distribution.
+  !
+  call read_kdist_gas_names(kdist_file, kdist_gas_names)
+  !
+  ! Which gases will be included in the calculation?
+  !    By default we'll use all the gases the k-distribution can handle, but
+  !    we could provide variants i.e. using equivalent concentrations per RFMIP
+  !
+  gases_to_use = kdist_gas_names
+  print *, "Radiation calculation uses gases "
+  print *, "  ", [(trim(gases_to_use(b)) // " ", b = 1, size(gases_to_use))]
+
+  ! --------------------------------------------------
+  !
+  ! Prepare data for use in rte+rrtmgp
+  !
+  !
+  ! Allocation on assignment within reading routines
+  !
+  call read_and_block_pt(rfmip_file, block_size, p_lay, p_lev, t_lay, t_lev)
+  !
+  ! Are the arrays ordered in the vertical with 1 at the top or the bottom of the domain?
+  !
+  top_at_1 = p_lay(1, 1, 1) < p_lay(1, nlay, 1)
+
+  !
+  ! Read the gas concentrations and surface properties
+  !
+  call read_and_block_gases_ty(rfmip_file, block_size, gases_to_use, gas_conc_array)
+  call read_and_block_sw_bc(rfmip_file, block_size, surface_albedo, total_solar_irradiance, solar_zenith_angle)
+  !
+  ! Read k-distribution information. load_and_init() reads data from netCDF and calls
+  !   k_dist%init(); users might want to use their own reading methods
+  !
+  call load_and_init(k_dist, trim(kdist_file), gas_conc_array(1))
+  if(.not. k_dist%source_is_external()) &
+    stop "rrtmgp_rfmip_sw: k-distribution file isn't SW"
+
+  allocate(toa_flux(block_size, k_dist%get_ngpt()), &
+           def_tsi(block_size), mu0(block_size), usecol(block_size))
+  !
+  ! RRTMGP won't run with pressure less than its minimum. The top level in the RFMIP file
+  !   is set to 10^-3 Pa. Here we pretend the layer is just a bit less deep.
+  !   This introduces an error but shows input sanitizing.
+  !
+  if(top_at_1) then
+    p_lev(:,1,:) = k_dist%get_press_ref_min() + epsilon(k_dist%get_press_ref_min())
+  else
+    p_lev(:,nlay+1,:) &
+                 = k_dist%get_press_ref_min() + epsilon(k_dist%get_press_ref_min())
+  end if
+
+  !
+  ! Allocate space for output fluxes (accessed via pointers in ty_fluxes_broadband),
+  !   gas optical properties, and source functions. The %alloc() routines carry along
+  !   the spectral discretization from the k-distribution.
+  !
+  allocate(flux_up(    block_size, nlay+1, nblocks), &
+           flux_dn(    block_size, nlay+1, nblocks))
+  call stop_on_err(optical_props%alloc_2str(block_size, nlay, k_dist))
+  ! --------------------------------------------------
+  !
+  ! Loop over blocks
+  !
+  do b = 1, nblocks
+    fluxes%flux_up => flux_up(:,:,b)
+    fluxes%flux_dn => flux_dn(:,:,b)
+    !
+    ! Compute the optical properties of the atmosphere and the Planck source functions
+    !    from pressures, temperatures, and gas concentrations...
+    !
+    call stop_on_err(k_dist%gas_optics(p_lay(:,:,b), &
+                                       p_lev(:,:,b),       &
+                                       t_lay(:,:,b),       &
+                                       gas_conc_array(b),  &
+                                       optical_props,      &
+                                       toa_flux))
+    !
+    ! Normalize incoming solar flux to match RFMIP specification
+    !
+    def_tsi(1:ncol) = sum(toa_flux, dim=2)
+    do igpt = 1, k_dist%get_ngpt()
+      do icol = 1, block_size
+        toa_flux(icol,igpt) = toa_flux(icol,igpt) * total_solar_irradiance(icol,b)/def_tsi(icol)
+      end do
+    end do
+    !
+    ! RTE will fail if passed solar zenith angles greater than 90 degree. We replace any with
+    !   nighttime columns with a default solar zenith angle. We'll mask these out later, of
+    !   course, but this gives us more work and so a better measure of timing.
+    !
+    usecol(1:block_size)  = solar_zenith_angle(:,b) < 90._wp - 2._wp * spacing(90._wp)
+    mu0(1:block_size) = merge(cos(solar_zenith_angle(:,b) * acos(-1._wp)/180._wp), 0._wp, usecol)
+    !
+    ! ... and compute the spectrally-resolved fluxes, providing reduced values
+    !    via ty_fluxes_broadband
+    !
+    call stop_on_err(rte_sw(optical_props,   &
+                            top_at_1,        &
+                            solar_zenith_angle(:,b), &
+                            toa_flux,         &
+                            spread(surface_albedo(:,b), 1, ncopies = k_dist%get_nband()), &
+                            spread(surface_albedo(:,b), 1, ncopies = k_dist%get_nband()), &
+                            fluxes))
+    !
+    ! Zero out fluxes for which the original solar zenith angle is <= 0.
+    !
+    do icol = 1, block_size
+      if(.not. usecol(icol)) then
+        flux_up(icol,:,b)  = 0._wp
+        flux_dn(icol,:,b)  = 0._wp
+      end if
+    end do
+  end do
+  ! --------------------------------------------------
+  call unblock_and_write(trim(flxup_file), 'rsu', flux_up)
+  call unblock_and_write(trim(flxdn_file), 'rsd', flux_dn)
+end program rrtmgp_rfmip_sw

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
@@ -203,8 +203,8 @@ program rrtmgp_rfmip_sw
   !   gas optical properties, and source functions. The %alloc() routines carry along
   !   the spectral discretization from the k-distribution.
   !
-  allocate(flux_up(    block_size, nlay+1, nblocks), &
-           flux_dn(    block_size, nlay+1, nblocks))
+  allocate(flux_up(block_size, nlay+1, nblocks), &
+           flux_dn(block_size, nlay+1, nblocks))
   call stop_on_err(optical_props%alloc_2str(block_size, nlay, k_dist))
   ! --------------------------------------------------
 #IFDEF USE_TIMING
@@ -271,7 +271,7 @@ program rrtmgp_rfmip_sw
     ret =  gptlstop('rte_sw')
 #ENDIF
     !
-    ! Zero out fluxes for which the original solar zenith angle is <= 0.
+    ! Zero out fluxes for which the original solar zenith angle is > 90 degrees.
     !
     do icol = 1, block_size
       if(.not. usecol(icol)) then

--- a/rrtmgp/mo_gas_concentrations.F90
+++ b/rrtmgp/mo_gas_concentrations.F90
@@ -84,8 +84,8 @@ contains
     integer :: igas
     ! ---------
     error_msg = ''
-    if (w < 0._wp) then
-      error_msg = 'ty_gas_concs%set_vmr: concentrations should be >= 0'
+    if (w < 0._wp .or. w > 1._wp) then
+      error_msg = 'ty_gas_concs%set_vmr: concentrations should be >= 0, <= 1'
       return
     endif
 
@@ -114,8 +114,8 @@ contains
     ! ---------
     error_msg = ''
 
-    if (any(w < 0._wp)) then
-      error_msg = 'ty_gas_concs%set_vmr: concentrations should be >= 0'
+    if (any(w < 0._wp .or. w > 1._wp)) then
+      error_msg = 'ty_gas_concs%set_vmr: concentrations should be >= 0, <= 1'
     endif
     if(this%nlay > 0) then
       if(size(w) /= this%nlay) error_msg = 'ty_gas_concs%set_vmr: different dimension (nlay)'
@@ -149,8 +149,8 @@ contains
     ! ---------
     error_msg = ''
 
-    if (any(w < 0._wp)) then
-      error_msg = 'ty_gas_concs%set_vmr: concentrations should be >= 0'
+    if (any(w < 0._wp .or. w > 1._wp)) then
+      error_msg = 'ty_gas_concs%set_vmr: concentrations should be >= 0, <= 1'
     endif
     if(this%ncol > 0 .and. size(w, 1) /= this%ncol) then
       error_msg = 'ty_gas_concs%set_vmr: different dimension (ncol)'

--- a/rte/mo_rte_sw.F90
+++ b/rte/mo_rte_sw.F90
@@ -90,8 +90,8 @@ contains
     !
     if(     size(mu0, 1)                                /=  ncol        ) &
       error_msg = "rte_sw: mu0 inconsistently sized"
-    if(any(mu0 <= 0._wp)) &
-      error_msg = "rte_sw: one or more mu0 <= 0"
+    if(any(mu0 <= 0._wp .or. mu0 > 1)) &
+      error_msg = "rte_sw: one or more mu0 <= 0 or > 1"
 
     if(any([size(inc_flux, 1),    size(inc_flux, 2)]    /= [ncol, ngpt])) &
       error_msg = "rte_sw: inc_flux inconsistently sized"


### PR DESCRIPTION
Timing uses General Purpose Timing Library (https://github.com/jmrosinski/GPTL). Use is set in rfmip-clear-sky via a Makefile macro.