### PR TITLE
Consistent use of `logical(wl)` throughout code

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -8,7 +8,7 @@ VPATH = $(RTE_DIR):$(RTE_KERNEL_DIR):$(RRTMGP_DIR):$(RRTMGP_KERNEL_DIR)
 include Makefile.conf
 include Makefile.rules
 
-all: librrtmgp.a librte.a
+all: librte.a librrtmgp.a 
 
 include $(RTE_DIR)/Make.depends
 include $(RRTMGP_DIR)/Make.depends

--- a/examples/mo_load_coefficients.F90
+++ b/examples/mo_load_coefficients.F90
@@ -20,7 +20,7 @@ module mo_load_coefficients
   !
   ! Modules for working with rte and rrtmgp
   !
-  use mo_rte_kind,           only: wp
+  use mo_rte_kind,           only: wp, wl
   use mo_gas_concentrations, only: ty_gas_concs
   use mo_gas_optics,         only: ty_gas_optics
   ! --------------------------------------------------
@@ -63,9 +63,9 @@ contains
     character(len=32), dimension(:),  allocatable :: gas_minor, identifier_minor
     character(len=32), dimension(:),  allocatable :: minor_gases_lower,               minor_gases_upper
     integer, dimension(:,:),          allocatable :: minor_limits_gpt_lower,          minor_limits_gpt_upper
-    logical, dimension(:),            allocatable :: minor_scales_with_density_lower, minor_scales_with_density_upper
+    logical(wl), dimension(:),        allocatable :: minor_scales_with_density_lower, minor_scales_with_density_upper
     character(len=32), dimension(:),  allocatable :: scaling_gas_lower,               scaling_gas_upper
-    logical, dimension(:),            allocatable :: scale_by_complement_lower,       scale_by_complement_upper
+    logical(wl), dimension(:),        allocatable :: scale_by_complement_lower,       scale_by_complement_upper
     integer, dimension(:),            allocatable :: kminor_start_lower,              kminor_start_upper
     real(wp), dimension(:,:,:),       allocatable :: kminor_lower,                    kminor_upper
 

--- a/examples/mo_simple_netcdf.F90
+++ b/examples/mo_simple_netcdf.F90
@@ -1,5 +1,5 @@
 module mo_simple_netcdf
-  use mo_rte_kind, only: wp
+  use mo_rte_kind, only: wp, wl
   use netcdf
   implicit none
   private
@@ -240,7 +240,7 @@ contains
     character(len=*), intent(in) :: varName
     integer,          intent(in) :: nx
     integer,      dimension(nx) :: read_logical_tmp
-    logical,      dimension(nx) :: read_logical_vec
+    logical(wl),  dimension(nx) :: read_logical_vec
 
     integer :: varid
     integer :: ix
@@ -280,7 +280,7 @@ contains
     !
     integer,          intent(in) :: ncid
     character(len=*), intent(in) :: dimName
-    logical :: dim_exists
+    logical(wl) :: dim_exists
 
     integer :: dimid
     dim_exists = nf90_inq_dimid(ncid, trim(dimName), dimid) == NF90_NOERR
@@ -292,7 +292,7 @@ contains
     !
     integer,          intent(in) :: ncid
     character(len=*), intent(in) :: varName
-    logical :: var_exists
+    logical(wl) :: var_exists
 
     integer :: varId
     var_exists = nf90_inq_varid(ncid, trim(varName), varid) == NF90_NOERR

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -13,8 +13,8 @@ FCINCLUDE += -I$(RRTMGP_DIR)
 # netcdf library, module files
 # C and Fortran interfaces respectively
 #
-NCHOME = /opt/local
-NFHOME = $(HOME)/Applications/$(FC)
+NCHOME = /usr/local
+NFHOME = /usr/local
 FCINCLUDE += -I$(NFHOME)/include
 LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
 LIBS      += -lnetcdff -lnetcdf
@@ -25,7 +25,7 @@ LIBS      += -lnetcdff -lnetcdf
 #
 TIMING=no
 # Compiler specific - e.g. turn off for pgfortran, set to -cpp for gfortran
-FCFLAGS += -fpp
+FCFLAGS += -cpp
 ifeq ($(TIMING),yes)
 	#
 	# Timing library

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -13,8 +13,8 @@ FCINCLUDE += -I$(RRTMGP_DIR)
 # netcdf library, module files
 # C and Fortran interfaces respectively
 #
-NCHOME = /usr/local
-NFHOME = /usr/local
+NCHOME = /opt/local
+NFHOME = $(HOME)/Applications/$(FC)
 FCINCLUDE += -I$(NFHOME)/include
 LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
 LIBS      += -lnetcdff -lnetcdf
@@ -25,7 +25,7 @@ LIBS      += -lnetcdff -lnetcdf
 #
 TIMING=no
 # Compiler specific - e.g. turn off for pgfortran, set to -cpp for gfortran
-FCFLAGS += -cpp
+FCFLAGS += -fpp
 ifeq ($(TIMING),yes)
 	#
 	# Timing library

--- a/examples/rfmip-clear-sky/mo_rfmip_io.F90
+++ b/examples/rfmip-clear-sky/mo_rfmip_io.F90
@@ -308,17 +308,17 @@ contains
       ! Read the values as a function of experiment
       gas_conc_temp_1d = read_field(ncid, gas_name_in_file, nexp_l) * read_scaling(ncid, gas_name_in_file)
 
-  	  do b = 1, nblocks
-          ! Does every value in this block belong to the same experiment?
-  	    if(all(exp_num(1,b) == exp_num(2:,b))) then
-  	      ! Provide a scalar value
-  		    call stop_on_err(gas_conc_array(b)%set_vmr(gas_names(g), gas_conc_temp_1d(exp_num(1,b))))
-  		  else
-  		  ! Create 2D field, blocksize x nlay, with scalar values from each experiment
-  		  call stop_on_err(gas_conc_array(b)%set_vmr(gas_names(g), &
-  		                                             spread(gas_conc_temp_1d(exp_num(:,b)), 2, ncopies = nlay_l)))
-  		  end if
-  	  end do
+      do b = 1, nblocks
+        ! Does every value in this block belong to the same experiment?
+        if(all(exp_num(1,b) == exp_num(2:,b))) then
+          ! Provide a scalar value
+          call stop_on_err(gas_conc_array(b)%set_vmr(gas_names(g), gas_conc_temp_1d(exp_num(1,b))))
+        else
+          ! Create 2D field, blocksize x nlay, with scalar values from each experiment
+          call stop_on_err(gas_conc_array(b)%set_vmr(gas_names(g), &
+          spread(gas_conc_temp_1d(exp_num(:,b)), 2, ncopies = nlay_l)))
+        end if
+      end do
 
     end do
     ncid = nf90_close(ncid)

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90
@@ -44,7 +44,7 @@ program rrtmgp_rfmip_lw
   !
   ! Working precision for real variables
   !
-  use mo_rte_kind,           only: wp
+  use mo_rte_kind,           only: wp, wl
   !
   ! Optical properties of the atmosphere as array of values
   !   In the longwave we include only absorption optical depth (_1scl)
@@ -97,7 +97,7 @@ program rrtmgp_rfmip_lw
                                 kdist_file = 'coefficients_lw.nc', &
                                 flxdn_file = 'rld_template.nc', flxup_file = 'rlu_template.nc'
   integer                    :: nargs, ncol, nlay, nexp, nblocks, block_size
-  logical                    :: top_at_1
+  logical(wl)                :: top_at_1
   integer                    :: b
   character(len=6)           :: block_size_char
 

--- a/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
+++ b/examples/rfmip-clear-sky/rrtmgp_rfmip_sw.F90
@@ -44,7 +44,7 @@ program rrtmgp_rfmip_sw
   !
   ! Working precision for real variables
   !
-  use mo_rte_kind,           only: wp
+  use mo_rte_kind,           only: wp, wl
   !
   ! Optical properties of the atmosphere as array of values
   !   In the longwave we include only absorption optical depth (_1scl)
@@ -93,7 +93,7 @@ program rrtmgp_rfmip_sw
                                 kdist_file = 'coefficients_sw.nc', &
                                 flxdn_file = 'rsd_template.nc', flxup_file = 'rsu_template.nc'
   integer                    :: nargs, ncol, nlay, nexp, nblocks, block_size
-  logical                    :: top_at_1
+  logical(wl)                :: top_at_1
   integer                    :: b, icol, igpt
   character(len=6)           :: block_size_char
 

--- a/rrtmgp/kernels/mo_gas_optics_kernels.F90
+++ b/rrtmgp/kernels/mo_gas_optics_kernels.F90
@@ -15,7 +15,7 @@
 !   source functions.
 
 module mo_gas_optics_kernels
-  use mo_rte_kind,      only: wp
+  use mo_rte_kind,      only : wp, wl
   use mo_util_string,   only : string_loc_in_array
   implicit none
 
@@ -38,25 +38,25 @@ contains
     ! input dimensions
     integer,                            intent(in) :: ncol,nlay
     integer,                            intent(in) :: ngas,nflav,neta,npres,ntemp
-    integer,  dimension(2,nflav),       intent(in) :: flavor
-    real(wp), dimension(npres),         intent(in) :: press_ref_log
-    real(wp), dimension(npres),         intent(in) :: temp_ref
+    integer,     dimension(2,nflav),    intent(in) :: flavor
+    real(wp),    dimension(npres),      intent(in) :: press_ref_log
+    real(wp),    dimension(npres),      intent(in) :: temp_ref
     real(wp),                           intent(in) :: press_ref_log_delta, &
                                                       temp_ref_min, temp_ref_delta, &
                                                       press_ref_trop_log
-    real(wp), dimension(2,0:ngas,ntemp),intent(in) :: vmr_ref
+    real(wp),    dimension(2,0:ngas,ntemp), intent(in) :: vmr_ref
 
     ! inputs from profile or parent function
-    real(wp), dimension(ncol,nlay),        intent(in) :: play, tlay
-    real(wp), dimension(ncol,nlay,0:ngas), intent(in) :: col_gas
+    real(wp),    dimension(ncol,nlay),        intent(in) :: play, tlay
+    real(wp),    dimension(ncol,nlay,0:ngas), intent(in) :: col_gas
 
     ! outputs
-    integer,  dimension(ncol,nlay), intent(out) :: jtemp, jpress
-    logical,  dimension(ncol,nlay), intent(out) :: tropo
-    integer,  dimension(2,    nflav,ncol,nlay), intent(out) :: jeta
-    real(wp), dimension(2,    nflav,ncol,nlay), intent(out) :: col_mix
-    real(wp), dimension(2,2,2,nflav,ncol,nlay), intent(out) :: fmajor
-    real(wp), dimension(2,2,  nflav,ncol,nlay), intent(out) :: fminor
+    integer,     dimension(ncol,nlay), intent(out) :: jtemp, jpress
+    logical(wl), dimension(ncol,nlay), intent(out) :: tropo
+    integer,     dimension(2,    nflav,ncol,nlay), intent(out) :: jeta
+    real(wp),    dimension(2,    nflav,ncol,nlay), intent(out) :: col_mix
+    real(wp),    dimension(2,2,2,nflav,ncol,nlay), intent(out) :: fmajor
+    real(wp),    dimension(2,2,  nflav,ncol,nlay), intent(out) :: fminor
     ! -----------------
     ! local
     real(wp), dimension(ncol,nlay) :: ftemp, fpress ! interpolation fraction for temperature, pressure
@@ -163,24 +163,24 @@ contains
     integer,                                intent(in) :: idx_h2o
     ! ---------------------
     ! inputs from object
-    integer,  dimension(2,ngpt),                  intent(in) :: gpoint_flavor
-    integer,  dimension(2,nbnd),                  intent(in) :: band_lims_gpt
-    real(wp), dimension(ngpt,neta,npres+1,ntemp), intent(in) :: kmajor
-    real(wp), dimension(nminorklower,neta,ntemp), intent(in) :: kminor_lower
-    real(wp), dimension(nminorkupper,neta,ntemp), intent(in) :: kminor_upper
-    integer,  dimension(2,nminorlower),           intent(in) :: minor_limits_gpt_lower
-    integer,  dimension(2,nminorupper),           intent(in) :: minor_limits_gpt_upper
-    logical,  dimension(  nminorlower),           intent(in) :: minor_scales_with_density_lower
-    logical,  dimension(  nminorupper),           intent(in) :: minor_scales_with_density_upper
-    logical,  dimension(  nminorlower),           intent(in) :: scale_by_complement_lower
-    logical,  dimension(  nminorupper),           intent(in) :: scale_by_complement_upper
-    integer,  dimension(  nminorlower),           intent(in) :: idx_minor_lower
-    integer,  dimension(  nminorupper),           intent(in) :: idx_minor_upper
-    integer,  dimension(  nminorlower),           intent(in) :: idx_minor_scaling_lower
-    integer,  dimension(  nminorupper),           intent(in) :: idx_minor_scaling_upper
-    integer,  dimension(  nminorlower),           intent(in) :: kminor_start_lower
-    integer,  dimension(  nminorupper),           intent(in) :: kminor_start_upper
-    logical,  dimension(ncol,nlay),               intent(in) :: tropo
+    integer,     dimension(2,ngpt),                  intent(in) :: gpoint_flavor
+    integer,     dimension(2,nbnd),                  intent(in) :: band_lims_gpt
+    real(wp),    dimension(ngpt,neta,npres+1,ntemp), intent(in) :: kmajor
+    real(wp),    dimension(nminorklower,neta,ntemp), intent(in) :: kminor_lower
+    real(wp),    dimension(nminorkupper,neta,ntemp), intent(in) :: kminor_upper
+    integer,     dimension(2,nminorlower),           intent(in) :: minor_limits_gpt_lower
+    integer,     dimension(2,nminorupper),           intent(in) :: minor_limits_gpt_upper
+    logical(wl), dimension(  nminorlower),           intent(in) :: minor_scales_with_density_lower
+    logical(wl), dimension(  nminorupper),           intent(in) :: minor_scales_with_density_upper
+    logical(wl), dimension(  nminorlower),           intent(in) :: scale_by_complement_lower
+    logical(wl), dimension(  nminorupper),           intent(in) :: scale_by_complement_upper
+    integer,     dimension(  nminorlower),           intent(in) :: idx_minor_lower
+    integer,     dimension(  nminorupper),           intent(in) :: idx_minor_upper
+    integer,     dimension(  nminorlower),           intent(in) :: idx_minor_scaling_lower
+    integer,     dimension(  nminorupper),           intent(in) :: idx_minor_scaling_upper
+    integer,     dimension(  nminorlower),           intent(in) :: kminor_start_lower
+    integer,     dimension(  nminorupper),           intent(in) :: kminor_start_upper
+    logical(wl), dimension(ncol,nlay),               intent(in) :: tropo
     ! ---------------------
     ! inputs from profile or parent function
     real(wp), dimension(2,    nflav,ncol,nlay       ), intent(in) :: col_mix
@@ -197,7 +197,7 @@ contains
     ! ---------------------
     ! Local variables
     !
-    logical                    :: top_at_1
+    logical(wl)                :: top_at_1
     integer, dimension(ncol,2) :: itropo_lower, itropo_upper
     ! ----------------------------------------------------------------
 
@@ -291,11 +291,11 @@ contains
     real(wp), dimension(ngpt,neta,npres+1,ntemp), intent(in) :: kmajor
 
     ! inputs from profile or parent function
-    real(wp), dimension(2,    nflav,ncol,nlay), intent(in) :: col_mix
-    real(wp), dimension(2,2,2,nflav,ncol,nlay), intent(in) :: fmajor
-    integer,  dimension(2,    nflav,ncol,nlay), intent(in) :: jeta
-    logical,  dimension(ncol,nlay), intent(in) :: tropo
-    integer,  dimension(ncol,nlay), intent(in) :: jtemp, jpress
+    real(wp),    dimension(2,    nflav,ncol,nlay), intent(in) :: col_mix
+    real(wp),    dimension(2,2,2,nflav,ncol,nlay), intent(in) :: fmajor
+    integer,     dimension(2,    nflav,ncol,nlay), intent(in) :: jeta
+    logical(wl), dimension(ncol,nlay), intent(in) :: tropo
+    integer,     dimension(ncol,nlay), intent(in) :: jtemp, jpress
 
     ! outputs
     real(wp), dimension(ngpt,nlay,ncol), intent(inout) :: tau
@@ -348,24 +348,24 @@ contains
                                       col_gas,fminor,jeta,   &
                                       layer_limits,jtemp,    &
                                       tau) bind(C, name="gas_optical_depths_minor")
-    integer,                                  intent(in ) :: ncol,nlay,ngpt
-    integer,                                  intent(in ) :: ngas,nflav
-    integer,                                  intent(in ) :: npres,neta,nminor,nminork
-    integer,                                  intent(in ) :: idx_h2o
-    integer,  dimension(ngpt),                intent(in ) :: gpt_flv
-    real(wp), dimension(nminork,neta,npres),  intent(in ) :: kminor
-    integer,  dimension(2,nminor),            intent(in ) :: minor_limits_gpt
-    logical,  dimension(  nminor),            intent(in ) :: minor_scales_with_density
-    logical,  dimension(  nminor),            intent(in ) :: scale_by_complement
-    integer,  dimension(  nminor),            intent(in ) :: kminor_start
-    integer,  dimension(  nminor),            intent(in ) :: idx_minor, idx_minor_scaling
-    real(wp), dimension(ncol,nlay),           intent(in ) :: play, tlay
-    real(wp), dimension(ncol,nlay,0:ngas),    intent(in ) :: col_gas
-    real(wp), dimension(2,2,nflav,ncol,nlay), intent(in ) :: fminor
-    integer,  dimension(2,  nflav,ncol,nlay), intent(in ) :: jeta
-    integer,  dimension(ncol, 2),             intent(in ) :: layer_limits
-    integer,  dimension(ncol,nlay),           intent(in ) :: jtemp
-    real(wp), dimension(ngpt,nlay,ncol),      intent(out) :: tau
+    integer,                                     intent(in ) :: ncol,nlay,ngpt
+    integer,                                     intent(in ) :: ngas,nflav
+    integer,                                     intent(in ) :: npres,neta,nminor,nminork
+    integer,                                     intent(in ) :: idx_h2o
+    integer,     dimension(ngpt),                intent(in ) :: gpt_flv
+    real(wp),    dimension(nminork,neta,npres),  intent(in ) :: kminor
+    integer,     dimension(2,nminor),            intent(in ) :: minor_limits_gpt
+    logical(wl), dimension(  nminor),            intent(in ) :: minor_scales_with_density
+    logical(wl), dimension(  nminor),            intent(in ) :: scale_by_complement
+    integer,     dimension(  nminor),            intent(in ) :: kminor_start
+    integer,     dimension(  nminor),            intent(in ) :: idx_minor, idx_minor_scaling
+    real(wp),    dimension(ncol,nlay),           intent(in ) :: play, tlay
+    real(wp),    dimension(ncol,nlay,0:ngas),    intent(in ) :: col_gas
+    real(wp),    dimension(2,2,nflav,ncol,nlay), intent(in ) :: fminor
+    integer,     dimension(2,  nflav,ncol,nlay), intent(in ) :: jeta
+    integer,     dimension(ncol, 2),             intent(in ) :: layer_limits
+    integer,     dimension(ncol,nlay),           intent(in ) :: jtemp
+    real(wp),    dimension(ngpt,nlay,ncol),      intent(out) :: tau
     ! -----------------
     ! local variables
     real(wp), parameter :: PaTohPa = 0.01
@@ -441,20 +441,20 @@ contains
                                   idx_h2o, col_dry,col_gas,    &
                                   fminor,jeta,tropo,jtemp,     &
                                   tau_rayleigh) bind(C, name="compute_tau_rayleigh")
-    integer,                                  intent(in ) :: ncol,nlay,nbnd,ngpt
-    integer,                                  intent(in ) :: ngas,nflav,neta,npres,ntemp
-    integer,  dimension(2,ngpt),              intent(in ) :: gpoint_flavor
-    integer,  dimension(2,nbnd),              intent(in ) :: band_lims_gpt ! start and end g-point for each band
-    real(wp), dimension(ngpt,neta,ntemp,2),   intent(in ) :: krayl
-    integer,                                  intent(in ) :: idx_h2o
-    real(wp), dimension(ncol,nlay),           intent(in ) :: col_dry
-    real(wp), dimension(ncol,nlay,0:ngas),    intent(in ) :: col_gas
-    real(wp), dimension(2,2,nflav,ncol,nlay), intent(in ) :: fminor
-    integer,  dimension(2,  nflav,ncol,nlay), intent(in ) :: jeta
-    logical,  dimension(ncol,nlay),           intent(in ) :: tropo
-    integer,  dimension(ncol,nlay),           intent(in ) :: jtemp
+    integer,                                     intent(in ) :: ncol,nlay,nbnd,ngpt
+    integer,                                     intent(in ) :: ngas,nflav,neta,npres,ntemp
+    integer,     dimension(2,ngpt),              intent(in ) :: gpoint_flavor
+    integer,     dimension(2,nbnd),              intent(in ) :: band_lims_gpt ! start and end g-point for each band
+    real(wp),    dimension(ngpt,neta,ntemp,2),   intent(in ) :: krayl
+    integer,                                     intent(in ) :: idx_h2o
+    real(wp),    dimension(ncol,nlay),           intent(in ) :: col_dry
+    real(wp),    dimension(ncol,nlay,0:ngas),    intent(in ) :: col_gas
+    real(wp),    dimension(2,2,nflav,ncol,nlay), intent(in ) :: fminor
+    integer,     dimension(2,  nflav,ncol,nlay), intent(in ) :: jeta
+    logical(wl), dimension(ncol,nlay),           intent(in ) :: tropo
+    integer,     dimension(ncol,nlay),           intent(in ) :: jtemp
     ! outputs
-    real(wp), dimension(ngpt,nlay,ncol),      intent(out) :: tau_rayleigh
+    real(wp),    dimension(ngpt,nlay,ncol),      intent(out) :: tau_rayleigh
     ! -----------------
     ! local variables
     real(wp) :: k(ngpt) ! rayleigh scattering coefficient
@@ -489,15 +489,15 @@ contains
                     sfc_src, lay_src, lev_src_inc, lev_src_dec) bind(C, name="compute_Planck_source")
     integer,                                    intent(in) :: ncol, nlay, nbnd, ngpt
     integer,                                    intent(in) :: nflav, neta, npres, ntemp, nPlanckTemp
-    real(wp), dimension(ncol,nlay  ),           intent(in) :: tlay
-    real(wp), dimension(ncol,nlay+1),           intent(in) :: tlev
-    real(wp), dimension(ncol       ),           intent(in) :: tsfc
+    real(wp),    dimension(ncol,nlay  ),        intent(in) :: tlay
+    real(wp),    dimension(ncol,nlay+1),        intent(in) :: tlev
+    real(wp),    dimension(ncol       ),        intent(in) :: tsfc
     integer,                                    intent(in) :: sfc_lay
     ! Interpolation variables
-    real(wp), dimension(2,2,2,nflav,ncol,nlay), intent(in) :: fmajor
-    integer,  dimension(2,    nflav,ncol,nlay), intent(in) :: jeta
-    logical,  dimension(            ncol,nlay), intent(in) :: tropo
-    integer,  dimension(            ncol,nlay), intent(in) :: jtemp, jpress
+    real(wp),    dimension(2,2,2,nflav,ncol,nlay), intent(in) :: fmajor
+    integer,     dimension(2,    nflav,ncol,nlay), intent(in) :: jeta
+    logical(wl), dimension(            ncol,nlay), intent(in) :: tropo
+    integer,     dimension(            ncol,nlay), intent(in) :: jtemp, jpress
     ! Table-specific
     integer, dimension(ngpt),                     intent(in) :: gpoint_bands ! start and end g-point for each band
     integer, dimension(2, nbnd),                  intent(in) :: band_lims_gpt ! start and end g-point for each band

--- a/rrtmgp/mo_gas_optics.F90
+++ b/rrtmgp/mo_gas_optics.F90
@@ -371,9 +371,9 @@ contains
     class(ty_optical_props_arry),     intent(inout) :: optical_props !inout because components are allocated
     ! Interpolation coefficients for use in internal source function
     integer,     dimension(            ncol, nlay), intent(  out) :: jtemp, jpress
-    integer,     dimension(2,    this%get_nflav(),ncol, nlay), intent(  out) :: jeta
+    integer,     dimension(2,    get_nflav(this),ncol, nlay), intent(  out) :: jeta
     logical(wl), dimension(            ncol, nlay), intent(  out) :: tropo
-    real(wp),    dimension(2,2,2,this%get_nflav(),ncol, nlay), intent(  out) :: fmajor
+    real(wp),    dimension(2,2,2,get_nflav(this),ncol, nlay), intent(  out) :: fmajor
     character(len=128)                                         :: error_msg
 
     ! Optional inputs
@@ -571,9 +571,9 @@ contains
     ! Interplation coefficients
     integer,  dimension(ncol,nlay),        intent(in ) :: jtemp, jpress
     logical(wl), dimension(ncol,nlay),     intent(in ) :: tropo
-    real(wp),    dimension(2,2,2,this%get_nflav(),ncol,nlay),   &
+    real(wp),    dimension(2,2,2,get_nflav(this),ncol,nlay),   &
                                            intent(in ) :: fmajor
-    integer,  dimension(2,   this%get_nflav(),ncol,nlay),   &
+    integer,  dimension(2,   get_nflav(this),ncol,nlay),   &
                                            intent(in ) :: jeta
     class(ty_source_func_lw    ),          intent(inout) :: sources
     real(wp), dimension(ncol,nlay+1),      intent(in ), &
@@ -1113,7 +1113,7 @@ contains
   !
   pure function get_gases(this)
     class(ty_gas_optics), intent(in) :: this
-    character(32), dimension(this%get_ngas())     :: get_gases
+    character(32), dimension(get_ngas(this))     :: get_gases
 
     get_gases = this%gas_names
   end function get_gases

--- a/rrtmgp/mo_gas_optics.F90
+++ b/rrtmgp/mo_gas_optics.F90
@@ -97,11 +97,11 @@ module mo_gas_optics
     ! Water vapor self- and foreign continua work like this, as do
     !   all collision-induced abosption pairs
     !
-    logical, dimension(:), allocatable :: minor_scales_with_density_lower, &
-                                          minor_scales_with_density_upper
-    logical, dimension(:), allocatable :: scale_by_complement_lower, scale_by_complement_upper
-    integer, dimension(:), allocatable :: idx_minor_lower,           idx_minor_upper
-    integer, dimension(:), allocatable :: idx_minor_scaling_lower,   idx_minor_scaling_upper
+    logical(wl), dimension(:), allocatable :: minor_scales_with_density_lower, &
+                                              minor_scales_with_density_upper
+    logical(wl), dimension(:), allocatable :: scale_by_complement_lower, scale_by_complement_upper
+    integer,     dimension(:), allocatable :: idx_minor_lower,           idx_minor_upper
+    integer,     dimension(:), allocatable :: idx_minor_scaling_lower,   idx_minor_scaling_upper
     !
     ! Index into table of absorption coefficients
     !
@@ -135,7 +135,7 @@ module mo_gas_optics
     ! Ancillary
     ! -----------------------------------------------------------------------------------
     ! Index into %gas_names -- is this a key species in any band?
-    logical, dimension(:), allocatable :: is_key
+    logical(wl), dimension(:), allocatable :: is_key
     ! -----------------------------------------------------------------------------------
 
   contains
@@ -236,10 +236,10 @@ contains
     ! ----------------------------------------------------------
     ! Local variables
     ! Interpolation coefficients for use in source function
-    integer,  dimension(size(play,dim=1), size(play,dim=2)) :: jtemp, jpress
-    logical,  dimension(size(play,dim=1), size(play,dim=2)) :: tropo
-    real(wp), dimension(2,2,2,this%get_nflav(),size(play,dim=1), size(play,dim=2)) :: fmajor
-    integer,  dimension(2,    this%get_nflav(),size(play,dim=1), size(play,dim=2)) :: jeta
+    integer,     dimension(size(play,dim=1), size(play,dim=2)) :: jtemp, jpress
+    logical(wl), dimension(size(play,dim=1), size(play,dim=2)) :: tropo
+    real(wp),    dimension(2,2,2,this%get_nflav(),size(play,dim=1), size(play,dim=2)) :: fmajor
+    integer,     dimension(2,    this%get_nflav(),size(play,dim=1), size(play,dim=2)) :: jeta
 
     integer :: ncol, nlay, ngpt, nband, ngas, nflav
     ! ----------------------------------------------------------
@@ -317,10 +317,10 @@ contains
     ! ----------------------------------------------------------
     ! Local variables
     ! Interpolation coefficients for use in source function
-    integer,  dimension(size(play,dim=1), size(play,dim=2)) :: jtemp, jpress
-    logical,  dimension(size(play,dim=1), size(play,dim=2)) :: tropo
-    real(wp), dimension(2,2,2,this%get_nflav(),size(play,dim=1), size(play,dim=2)) :: fmajor
-    integer,  dimension(2,    this%get_nflav(),size(play,dim=1), size(play,dim=2)) :: jeta
+    integer,     dimension(size(play,dim=1), size(play,dim=2)) :: jtemp, jpress
+    logical(wl), dimension(size(play,dim=1), size(play,dim=2)) :: tropo
+    real(wp),    dimension(2,2,2,this%get_nflav(),size(play,dim=1), size(play,dim=2)) :: fmajor
+    integer,     dimension(2,    this%get_nflav(),size(play,dim=1), size(play,dim=2)) :: jeta
 
     integer :: ncol, nlay, ngpt, nband, ngas, nflav
     ! ----------------------------------------------------------
@@ -370,10 +370,10 @@ contains
     type(ty_gas_concs),               intent(in   ) :: gas_desc  ! Gas volume mixing ratios
     class(ty_optical_props_arry),     intent(inout) :: optical_props !inout because components are allocated
     ! Interpolation coefficients for use in internal source function
-    integer,  dimension(            ncol, nlay), intent(  out) :: jtemp, jpress
-    integer,  dimension(2,    this%get_nflav(),ncol, nlay), intent(  out) :: jeta
-    logical,  dimension(            ncol, nlay), intent(  out) :: tropo
-    real(wp), dimension(2,2,2,this%get_nflav(),ncol, nlay), intent(  out) :: fmajor
+    integer,     dimension(            ncol, nlay), intent(  out) :: jtemp, jpress
+    integer,     dimension(2,    this%get_nflav(),ncol, nlay), intent(  out) :: jeta
+    logical(wl), dimension(            ncol, nlay), intent(  out) :: tropo
+    real(wp),    dimension(2,2,2,this%get_nflav(),ncol, nlay), intent(  out) :: fmajor
     character(len=128)                                         :: error_msg
 
     ! Optional inputs
@@ -547,7 +547,7 @@ contains
     if (error_msg /= '') return
 
     ! Combine optical depths and reorder for radiative transfer solver.
-    call combine_and_reorder(tau, tau_rayleigh, allocated(this%krayl), optical_props)
+    call combine_and_reorder(tau, tau_rayleigh, logical(allocated(this%krayl), wl), optical_props)
 
   end function compute_gas_taus
   !------------------------------------------------------------------------------------------
@@ -570,12 +570,12 @@ contains
     real(wp), dimension(ncol),             intent(in ) :: tsfc   ! surface skin temperatures [K]
     ! Interplation coefficients
     integer,  dimension(ncol,nlay),        intent(in ) :: jtemp, jpress
-    logical,  dimension(ncol,nlay),        intent(in ) :: tropo
-    real(wp), dimension(2,2,2,this%get_nflav(),ncol,nlay),   &
+    logical(wl), dimension(ncol,nlay),     intent(in ) :: tropo
+    real(wp),    dimension(2,2,2,this%get_nflav(),ncol,nlay),   &
                                            intent(in ) :: fmajor
     integer,  dimension(2,   this%get_nflav(),ncol,nlay),   &
                                            intent(in ) :: jeta
-    class(ty_source_func_lw    ),        intent(inout) :: sources
+    class(ty_source_func_lw    ),          intent(inout) :: sources
     real(wp), dimension(ncol,nlay+1),      intent(in ), &
                                       optional, target :: tlev          ! level temperatures [K]
     character(len=128)                                 :: error_msg
@@ -679,11 +679,11 @@ contains
                                                              minor_gases_upper
     integer,            dimension(:,:),     intent(in   ) :: minor_limits_gpt_lower, &
                                                              minor_limits_gpt_upper
-    logical,            dimension(:),       intent(in   ) :: minor_scales_with_density_lower, &
+    logical(wl),        dimension(:),       intent(in   ) :: minor_scales_with_density_lower, &
                                                              minor_scales_with_density_upper
     character(len=*),   dimension(:),       intent(in   ) :: scaling_gas_lower, &
                                                              scaling_gas_upper
-    logical,            dimension(:),       intent(in   ) :: scale_by_complement_lower,&
+    logical(wl),        dimension(:),       intent(in   ) :: scale_by_complement_lower,&
                                                              scale_by_complement_upper
     integer,            dimension(:),       intent(in   ) :: kminor_start_lower,&
                                                              kminor_start_upper
@@ -762,13 +762,13 @@ contains
     integer,  dimension(:,:),     intent(in) :: &
                                                 minor_limits_gpt_lower, &
                                                 minor_limits_gpt_upper
-    logical,  dimension(:),       intent(in) :: &
+    logical(wl), dimension(:),    intent(in) :: &
                                                 minor_scales_with_density_lower, &
                                                 minor_scales_with_density_upper
     character(len=*),   dimension(:),intent(in) :: &
                                                 scaling_gas_lower, &
                                                 scaling_gas_upper
-    logical,  dimension(:),       intent(in) :: &
+    logical(wl), dimension(:),    intent(in) :: &
                                                 scale_by_complement_lower, &
                                                 scale_by_complement_upper
     integer,  dimension(:),       intent(in) :: &
@@ -850,21 +850,21 @@ contains
                                                 minor_gases_upper
     integer,  dimension(:,:),     intent(in) :: minor_limits_gpt_lower, &
                                                 minor_limits_gpt_upper
-    logical,  dimension(:),       intent(in) :: minor_scales_with_density_lower, &
+    logical(wl), dimension(:),    intent(in) :: minor_scales_with_density_lower, &
                                                 minor_scales_with_density_upper
     character(len=*),   dimension(:),&
                                   intent(in) :: scaling_gas_lower, &
                                                 scaling_gas_upper
-    logical,  dimension(:),       intent(in) :: scale_by_complement_lower, &
-                                                   scale_by_complement_upper
+    logical(wl), dimension(:),    intent(in) :: scale_by_complement_lower, &
+                                                scale_by_complement_upper
     integer,  dimension(:),       intent(in) :: kminor_start_lower, &
                                                 kminor_start_upper
     real(wp), dimension(:,:,:),   intent(in), &
                                  allocatable :: rayl_lower, rayl_upper
     character(len=128)                       :: err_message
     ! --------------------------------------------------------------------------
-    logical,  dimension(:),     allocatable :: gas_is_present
-    logical,  dimension(:),     allocatable :: key_species_present_init
+    logical(wl), dimension(:),  allocatable :: gas_is_present
+    logical(wl), dimension(:),  allocatable :: key_species_present_init
     integer,  dimension(:,:,:), allocatable :: key_species_red
     real(wp), dimension(:,:,:), allocatable :: vmr_ref_red
     character(len=256), &
@@ -1021,7 +1021,7 @@ contains
   function check_key_species_present_init(gas_names, &
     key_species_present_init) result(err_message)
 
-    logical, dimension(:), intent(in) :: key_species_present_init
+    logical(wl), dimension(:), intent(in) :: key_species_present_init
     character(len=*), dimension(:), intent(in) :: gas_names
 
     character(len=128)                             :: err_message
@@ -1073,7 +1073,7 @@ contains
     ! List of minor gases to be used in gas_optics()
     character(len=32), dimension(:), allocatable         :: get_minor_list
     ! Logical flag for minor species in specification (T = minor; F = not minor)
-    logical, dimension(size(names_spec))                 :: gas_is_present
+    logical(wl), dimension(size(names_spec))             :: gas_is_present
     integer                                              :: igas, icnt
 
     if (allocated(get_minor_list)) deallocate(get_minor_list)
@@ -1094,7 +1094,7 @@ contains
   !
   pure function source_is_internal(this)
     class(ty_gas_optics), intent(in) :: this
-    logical                                        :: source_is_internal
+    logical(wl)                                    :: source_is_internal
     source_is_internal = allocated(this%totplnk) .and. allocated(this%planck_frac)
   end function source_is_internal
   !--------------------------------------------------------------------------------------------------------------------
@@ -1103,7 +1103,7 @@ contains
   !
   pure function source_is_external(this)
     class(ty_gas_optics), intent(in) :: this
-    logical                                        :: source_is_external
+    logical(wl)                                    :: source_is_external
     source_is_external = allocated(this%solar_src)
   end function source_is_external
 
@@ -1219,7 +1219,7 @@ contains
   ! ---------------------------------------------------------------------------------------
   ! true is key_species_pair exists in key_species_list
   pure function key_species_pair_exists(key_species_list, key_species_pair)
-    logical :: key_species_pair_exists
+    logical(wl) :: key_species_pair_exists
     integer, dimension(:,:), intent(in) :: key_species_list
     integer, dimension(2), intent(in) :: key_species_pair
     integer :: i
@@ -1328,7 +1328,7 @@ contains
     integer,  dimension(:,:,:),   intent(in) :: key_species
     integer,  dimension(:,:,:), allocatable, intent(out) :: key_species_red
 
-    logical, dimension(:), allocatable, intent(out) :: key_species_present_init
+    logical(wl), dimension(:), allocatable, intent(out) :: key_species_present_init
     integer :: ip, ia, it, np, na, nt
 
     np = size(key_species,dim=1)
@@ -1385,11 +1385,11 @@ contains
                                   intent(in) :: minor_gases_atm
     integer,  dimension(:,:),     intent(in) :: &
                                                 minor_limits_gpt_atm
-    logical,  dimension(:),       intent(in) :: &
+    logical(wl), dimension(:),    intent(in) :: &
                                                 minor_scales_with_density_atm
     character(len=*),   dimension(:),intent(in) :: &
                                                 scaling_gas_atm
-    logical,  dimension(:), intent(in) :: &
+    logical(wl), dimension(:), intent(in) :: &
                                                 scale_by_complement_atm
     integer,  dimension(:), intent(in) :: &
                                                 kminor_start_atm
@@ -1399,11 +1399,11 @@ contains
                                   allocatable, intent(out) :: minor_gases_atm_red
     integer,  dimension(:,:),     allocatable, intent(out) :: &
                                                 minor_limits_gpt_atm_red
-    logical,  dimension(:),       allocatable, intent(out) :: &
+    logical(wl), dimension(:),    allocatable, intent(out) :: &
                                                 minor_scales_with_density_atm_red
-    character(len=*),   dimension(:),allocatable, intent(out) :: &
+    character(len=*),   dimension(:), allocatable, intent(out) :: &
                                                 scaling_gas_atm_red
-    logical,  dimension(:), allocatable, intent(out) :: &
+    logical(wl), dimension(:), allocatable, intent(out) :: &
                                                 scale_by_complement_atm_red
     integer,  dimension(:), allocatable, intent(out) :: &
                                                 kminor_start_atm_red
@@ -1412,7 +1412,7 @@ contains
     integer :: i, j
     integer :: idx_mnr, nm, tot_g, red_nm
     integer :: icnt, n_elim, ng
-    logical, dimension(:), allocatable :: gas_is_present
+    logical(wl), dimension(:), allocatable :: gas_is_present
 
     nm = size(minor_gases_atm)
     tot_g=0
@@ -1515,7 +1515,7 @@ contains
  subroutine combine_and_reorder(tau, tau_rayleigh, has_rayleigh, optical_props)
     real(wp), dimension(:,:,:),   intent(in) :: tau
     real(wp), dimension(:,:,:),   intent(in) :: tau_rayleigh
-    logical,                      intent(in) :: has_rayleigh
+    logical(wl),                  intent(in) :: has_rayleigh
     class(ty_optical_props_arry), intent(inout) :: optical_props
 
     integer :: ncol, nlay, ngpt, nmom

--- a/rrtmgp/mo_util_string.F90
+++ b/rrtmgp/mo_util_string.F90
@@ -17,6 +17,7 @@
 !
 ! -------------------------------------------------------------------------------------------------
 module mo_util_string
+  use mo_rte_kind, only : wl
   implicit none
   private
   public :: lower_case, string_in_array, string_loc_in_array
@@ -48,7 +49,7 @@ contains
   pure function string_in_array(string, array)
     character(len=*),               intent(in) :: string
     character(len=*), dimension(:), intent(in) :: array
-    logical                                    :: string_in_array
+    logical(wl)                                :: string_in_array
 
     integer :: i
     character(len=len_trim(string)) :: lc_string

--- a/rte/mo_fluxes.F90
+++ b/rte/mo_fluxes.F90
@@ -63,12 +63,12 @@ module mo_fluxes
     !
     function reduce_abstract(this, gpt_flux_up, gpt_flux_dn, spectral_disc, top_at_1, gpt_flux_dn_dir) result(error_msg)
       import ty_fluxes, ty_optical_props
-      import wp
+      import wp, wl
       class(ty_fluxes),                  intent(inout) :: this
       real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_up ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
       real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_dn ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
       class(ty_optical_props),           intent(in   ) :: spectral_disc  !< derived type with spectral information
-      logical(wl),                       intent(in   ) :: top_at_1
+      logical(kind=wl),                  intent(in   ) :: top_at_1
       real(kind=wp), dimension(:,:,:), optional, &
                                          intent(in   ) :: gpt_flux_dn_dir! Direct flux down
       character(len=128)                               :: error_msg
@@ -80,6 +80,7 @@ module mo_fluxes
     !
     function are_desired_abstract(this)
       import ty_fluxes
+      import wl
       class(ty_fluxes), intent(in   ) :: this
       logical(wl)                     :: are_desired_abstract
     end function are_desired_abstract
@@ -96,7 +97,7 @@ contains
     real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_up ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
     real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_dn ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
     class(ty_optical_props),           intent(in   ) :: spectral_disc  !< derived type with spectral information
-    logical(wl),                       intent(in   ) :: top_at_1
+    logical(kind=wl),                  intent(in   ) :: top_at_1
     real(kind=wp), dimension(:,:,:), optional, &
                                        intent(in   ) :: gpt_flux_dn_dir! Direct flux down
     character(len=128)                               :: error_msg
@@ -190,7 +191,7 @@ contains
   ! --------------------------------------------------------------------------------------
   function are_desired_broadband(this)
     class(ty_fluxes_broadband), intent(in   ) :: this
-    logical(wl),                              :: are_desired_broadband
+    logical(kind=wl)                          :: are_desired_broadband
 
     are_desired_broadband = any( [associated(this%flux_up),     &
                                   associated(this%flux_dn),     &

--- a/rte/mo_fluxes.F90
+++ b/rte/mo_fluxes.F90
@@ -17,7 +17,7 @@
 !
 ! -------------------------------------------------------------------------------------------------
 module mo_fluxes
-  use mo_rte_kind,      only: wp
+  use mo_rte_kind,      only: wp, wl
   use mo_optical_props, only: ty_optical_props
   use mo_fluxes_broadband_kernels, &
                         only: sum_broadband, net_broadband
@@ -68,7 +68,7 @@ module mo_fluxes
       real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_up ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
       real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_dn ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
       class(ty_optical_props),           intent(in   ) :: spectral_disc  !< derived type with spectral information
-      logical,                           intent(in   ) :: top_at_1
+      logical(wl),                       intent(in   ) :: top_at_1
       real(kind=wp), dimension(:,:,:), optional, &
                                          intent(in   ) :: gpt_flux_dn_dir! Direct flux down
       character(len=128)                               :: error_msg
@@ -81,7 +81,7 @@ module mo_fluxes
     function are_desired_abstract(this)
       import ty_fluxes
       class(ty_fluxes), intent(in   ) :: this
-      logical                         :: are_desired_abstract
+      logical(wl)                     :: are_desired_abstract
     end function are_desired_abstract
     ! ----------------------
   end interface
@@ -96,7 +96,7 @@ contains
     real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_up ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
     real(kind=wp), dimension(:,:,:),   intent(in   ) :: gpt_flux_dn ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
     class(ty_optical_props),           intent(in   ) :: spectral_disc  !< derived type with spectral information
-    logical,                           intent(in   ) :: top_at_1
+    logical(wl),                       intent(in   ) :: top_at_1
     real(kind=wp), dimension(:,:,:), optional, &
                                        intent(in   ) :: gpt_flux_dn_dir! Direct flux down
     character(len=128)                               :: error_msg
@@ -190,7 +190,7 @@ contains
   ! --------------------------------------------------------------------------------------
   function are_desired_broadband(this)
     class(ty_fluxes_broadband), intent(in   ) :: this
-    logical                                   :: are_desired_broadband
+    logical(wl),                              :: are_desired_broadband
 
     are_desired_broadband = any( [associated(this%flux_up),     &
                                   associated(this%flux_dn),     &

--- a/rte/mo_optical_props.F90
+++ b/rte/mo_optical_props.F90
@@ -39,7 +39,7 @@
 !
 ! -------------------------------------------------------------------------------------------------
 module mo_optical_props
-  use mo_rte_kind,              only: wp
+  use mo_rte_kind,              only: wp, wl
   use mo_optical_props_kernels, only: &
         increment_1scalar_by_1scalar, increment_1scalar_by_2stream, increment_1scalar_by_nstream, &
         increment_2stream_by_1scalar, increment_2stream_by_2stream, increment_2stream_by_nstream, &
@@ -291,7 +291,7 @@ contains
   ! -------------------------------------------------------------------------------------------------
   pure function is_initialized_base(this)
     class(ty_optical_props), intent(in) :: this
-    logical                             :: is_initialized_base
+    logical(wl)                         :: is_initialized_base
 
     is_initialized_base = allocated(this%band2gpt)
   end function is_initialized_base
@@ -1121,7 +1121,7 @@ contains
   !
   pure function bands_are_equal(this, that)
     class(ty_optical_props), intent(in) :: this, that
-    logical                             :: bands_are_equal
+    logical(wl)                         :: bands_are_equal
 
     bands_are_equal = this%get_nband() == that%get_nband() .and. &
                       this%get_nband() > 0
@@ -1137,7 +1137,7 @@ contains
   !
   pure function gpoints_are_equal(this, that)
     class(ty_optical_props), intent(in) :: this, that
-    logical                             :: gpoints_are_equal
+    logical(wl)                         :: gpoints_are_equal
 
     gpoints_are_equal = this%bands_are_equal(that) .and. &
                         this%get_ngpt() == that%get_ngpt()

--- a/rte/mo_rte_lw.F90
+++ b/rte/mo_rte_lw.F90
@@ -59,7 +59,7 @@ contains
     class(ty_optical_props_arry), intent(in   ) :: optical_props     ! Array of ty_optical_props. This type is abstract
                                                                      ! and needs to be made concrete, either as an array
                                                                      ! (class ty_optical_props_arry) or in some user-defined way
-    logical,                      intent(in   ) :: top_at_1          ! Is the top of the domain at index 1?
+    logical(wl),                  intent(in   ) :: top_at_1          ! Is the top of the domain at index 1?
                                                                      ! (if not, ordering is bottom-to-top)
     type(ty_source_func_lw),      intent(in   ) :: sources
     real(wp), dimension(:,:),     intent(in   ) :: sfc_emis    ! emissivity at surface [] (nband, ncol)

--- a/rte/mo_rte_sw.F90
+++ b/rte/mo_rte_sw.F90
@@ -46,7 +46,7 @@ contains
                   sfc_alb_dir, sfc_alb_dif,        &
                   fluxes, inc_flux_dif) result(error_msg)
     class(ty_optical_props_arry), intent(in   ) :: atmos           ! Optical properties provided as arrays
-    logical,                      intent(in   ) :: top_at_1        ! Is the top of the domain at index 1?
+    logical(wl),                  intent(in   ) :: top_at_1        ! Is the top of the domain at index 1?
                                                                    ! (if not, ordering is bottom-to-top)
     real(wp), dimension(:),       intent(in   ) :: mu0             ! cosine of solar zenith angle (ncol)
     real(wp), dimension(:,:),     intent(in   ) :: inc_flux,    &  ! incident flux at top of domain [W/m2] (ncol, ngpt)

--- a/rte/mo_source_functions.F90
+++ b/rte/mo_source_functions.F90
@@ -15,7 +15,7 @@
 !
 ! -------------------------------------------------------------------------------------------------
 module mo_source_functions
-  use mo_rte_kind,      only: wp
+  use mo_rte_kind,      only: wp, wl
   use mo_optical_props, only: ty_optical_props
   implicit none
   ! -------------------------------------------------------------------------------------------------
@@ -72,7 +72,7 @@ contains
   ! ------------------------------------------------------------------------------------------
   pure function is_allocated_lw(this)
     class(ty_source_func_lw), intent(in) :: this
-    logical                              :: is_allocated_lw
+    logical(wl)                          :: is_allocated_lw
 
     is_allocated_lw = this%is_initialized() .and. &
                       allocated(this%sfc_source)
@@ -125,7 +125,7 @@ contains
   ! ------------------------------------------------------------------------------------------
   pure function is_allocated_sw(this)
     class(ty_source_func_sw), intent(in) :: this
-    logical                              :: is_allocated_sw
+    logical(wl)                          :: is_allocated_sw
 
     is_allocated_sw = this%ty_optical_props%is_initialized() .and. &
                       allocated(this%toa_source)


### PR DESCRIPTION
This is the fix that makes the code use `c_bool` wherever logicals are used (`wl` kind as defined in `mo_rte_kind.F90`. I have done a full implementation throughout the code, but *not* in the extensions, as I have no methods of testing those.

In order to make the code run on GNU and Intel compilers, I had to convert the usage of `this%get_ngas()` in `dimension` definitions into `get_ngas(this)`.

To let clean builds work on single thread make, I had to swap the order of compilation of `librrtmgp.a` and `librte.a` as the latter needs to be compiled first.