### PR TITLE
Open coefficients files for read-only access

### DIFF
--- a/examples/mo_load_coefficients.F90
+++ b/examples/mo_load_coefficients.F90
@@ -97,7 +97,7 @@ contains
     !
     ! How big are the various arrays?
     !
-    if(nf90_open(trim(fileName), NF90_WRITE, ncid) /= NF90_NOERR) &
+    if(nf90_open(trim(fileName), NF90_NOWRITE, ncid) /= NF90_NOERR) &
       call stop_on_err("load_and_init(): can't open file " // trim(fileName))
     ntemps            = get_dim_size(ncid,'temperature')
     npress            = get_dim_size(ncid,'pressure')


### PR DESCRIPTION
Open coefficients files for read-only, rather than read-write access because we do NOT want to accidentally write to these files, nor do we want to require users to have write-permissions to load these files. Fixes #31. Tested and bit-for-bit with branch develop for RFMIP clear-sky example.