### PR TITLE
Config for PGI 19.4 on Daint

### DIFF
--- a/build/Makefile.conf.pgfortran-cscs
+++ b/build/Makefile.conf.pgfortran-cscs
@@ -3,8 +3,8 @@
 # Load the following modules to compile with PGI for CPU
 #
 #  module swap PrgEnv-cray PrgEnv-pgi
-#  module swap pgi pgi/18.10.0
-#  module load cray-netcdf cray-hdf5
+#  module swap pgi pgi/19.4.0
+#  module load cray-netcdf/4.6.3.0 cray-hdf5/1.10.5.0
 #  module unload cray-libsci_acc
 #
 #

--- a/build/Makefile.conf.pgfortran-cscs-gpu
+++ b/build/Makefile.conf.pgfortran-cscs-gpu
@@ -3,7 +3,8 @@
 # Load the following modules
 #
 #  module swap PrgEnv-cray PrgEnv-pgi
-#  module load cray-netcdf cray-hdf5
+#  module swap pgi pgi/19.4.0
+#  module load cray-netcdf/4.6.3.0 cray-hdf5/1.10.5.0
 #  module load craype-accel-nvidia60
 #  module unload cray-libsci_acc
 #
@@ -14,7 +15,7 @@ NCHOME =
 
 # Fortran compiler flags
 #FCFLAGS = -g -Minfo -Mbounds -Mchkptr -Mstandard -Kieee -Mchkstk -Mipa=fast,inline -acc -ta=tesla:6.5
-FCFLAGS = -g -ta=tesla:cc60,cuda9.1 -Minfo -Mbounds -Mchkptr -Mstandard -Kieee -Mchkstk                   -Mallocatable=03
+FCFLAGS = -g -ta=tesla:cc60,cuda9.2 -Minfo -Mbounds -Mchkptr -Mstandard -Kieee -Mchkstk                   -Mallocatable=03
 
 # Fortran .mod files, e.g. -I<include dir> if you have headers in a nonstandard directory <include dir>
 FCINCLUDE =


### PR DESCRIPTION
PGI 19 switched the default backend to LLVM. In order to avoid linking errors, newer version of HDF5 and NetCDF need to be used as they were built with PGI 19.1.