### PR TITLE
GPU optimizations (#44)

### DIFF
--- a/rrtmgp/kernels-openacc/mo_gas_optics_kernels.F90
+++ b/rrtmgp/kernels-openacc/mo_gas_optics_kernels.F90
@@ -69,7 +69,7 @@ contains
     !$acc enter data create(jtemp,jpress,tropo,jeta,col_mix,fmajor,fminor)
     !$acc enter data create(ftemp,fpress)
 
-    !$acc parallel loop collapse(2)
+    !$acc parallel loop gang vector collapse(2)
     do ilay = 1, nlay
       do icol = 1, ncol
         ! index and factor for temperature interpolation
@@ -90,7 +90,7 @@ contains
     ! loop over implemented combinations of major species
     ! PGI BUG WORKAROUND: if present(vmr_ref) isn't there, OpenACC runtime
     ! thinks it isn't present.
-    !$acc parallel loop collapse(4) private(igases) present(vmr_ref)
+    !$acc parallel loop gang vector collapse(4) private(igases) present(vmr_ref) 
     do ilay = 1, nlay
       do icol = 1, ncol
         ! loop over implemented combinations of major species
@@ -402,62 +402,82 @@ contains
     integer  :: icol, ilay, iflav, igpt, imnr
     integer  :: gptS, gptE
     integer  :: minor_start, minor_loc, extent
+
+    real(wp) :: myplay, mytlay, mycol_gas_h2o, mycol_gas_imnr, mycol_gas_0
+    real(wp) :: myfminor(2,2)
+    integer  :: myjtemp, myjeta(2), max_gpt_diff, igpt0
     ! -----------------
 
     extent = size(scale_by_complement,dim=1)
 
-    !$acc parallel loop collapse(3)
-    do imnr = 1, extent  ! loop over minor absorbers in each band
+    ! Find the largest number of g-points per band
+    max_gpt_diff = maxval( minor_limits_gpt(2,:) - minor_limits_gpt(1,:) )
+
+    !$acc parallel loop gang vector collapse(3)
+    do ilay = 1 , nlay
       do icol = 1, ncol
-        do ilay = 1 , nlay
+        do igpt0 = 0, max_gpt_diff
           !
           ! This check skips individual columns with no pressures in range
           !
-          if(layer_limits(icol,1) > 0) then
-            if (ilay >= layer_limits(icol,1)  .and. ilay <= layer_limits(icol,2) ) then
+          if ( layer_limits(icol,1) <= 0 .or. ilay < layer_limits(icol,1) .or. ilay > layer_limits(icol,2) ) cycle
+
+          myplay  = play (icol,ilay)
+          mytlay  = tlay (icol,ilay)
+          myjtemp = jtemp(icol,ilay)
+          mycol_gas_h2o = col_gas(icol,ilay,idx_h2o)
+          mycol_gas_0   = col_gas(icol,ilay,0)
+
+          do imnr = 1, extent
+
+            scaling = col_gas(icol,ilay,idx_minor(imnr))
+            if (minor_scales_with_density(imnr)) then
               !
-              ! Scaling of minor gas absortion coefficient begins with column amount of minor gas
+              ! NOTE: P needed in hPa to properly handle density scaling.
               !
-              scaling = col_gas(icol,ilay,idx_minor(imnr))
-              !
-              ! Density scaling (e.g. for h2o continuum, collision-induced absorption)
-              !
-              if (minor_scales_with_density(imnr)) then
-                !
-                ! NOTE: P needed in hPa to properly handle density scaling.
-                !
-                scaling = scaling * (PaTohPa*play(icol,ilay)/tlay(icol,ilay))
-                if(idx_minor_scaling(imnr) > 0) then  ! there is a second gas that affects this gas's absorption
-                  vmr_fact = 1._wp / col_gas(icol,ilay,0)
-                  dry_fact = 1._wp / (1._wp + col_gas(icol,ilay,idx_h2o) * vmr_fact)
-                  ! scale by density of special gas
-                  if (scale_by_complement(imnr)) then ! scale by densities of all gases but the special one
-                    scaling = scaling * (1._wp - col_gas(icol,ilay,idx_minor_scaling(imnr)) * vmr_fact * dry_fact)
-                  else
-                    scaling = scaling *          col_gas(icol,ilay,idx_minor_scaling(imnr)) * vmr_fact * dry_fact
-                  endif
+              scaling = scaling * (PaTohPa * myplay/mytlay)
+
+              if(idx_minor_scaling(imnr) > 0) then  ! there is a second gas that affects this gas's absorption
+                mycol_gas_imnr = col_gas(icol,ilay,idx_minor_scaling(imnr))
+                vmr_fact = 1._wp / mycol_gas_0
+                dry_fact = 1._wp / (1._wp + mycol_gas_h2o * vmr_fact)
+                ! scale by density of special gas
+                if (scale_by_complement(imnr)) then ! scale by densities of all gases but the special one
+                  scaling = scaling * (1._wp - mycol_gas_imnr * vmr_fact * dry_fact)
+                else
+                  scaling = scaling *          mycol_gas_imnr * vmr_fact * dry_fact
                 endif
               endif
-              !
-              ! Interpolation of absorption coefficient and calculation of optical depth
-              !
-              ! Which gpoint range does this minor gas affect?
-              gptS = minor_limits_gpt(1,imnr)
-              gptE = minor_limits_gpt(2,imnr)
+            endif
+
+            !
+            ! Interpolation of absorption coefficient and calculation of optical depth
+            !
+            ! Which gpoint range does this minor gas affect?
+            gptS = minor_limits_gpt(1,imnr)
+            gptE = minor_limits_gpt(2,imnr)
+            
+            ! Find the actual g-point to work on
+            igpt = igpt0 + gptS
+
+            ! Proceed only if the g-point is within the correct range
+            if (igpt <= gptE) then
               ! What is the starting point in the stored array of minor absorption coefficients?
               minor_start = kminor_start(imnr)
-              do igpt = gptS,gptE
-                tau_minor = 0._wp
-                iflav = gpt_flv(idx_tropo,igpt) ! eta interpolation depends on flavor
-                minor_loc = minor_start + (igpt - gptS) ! add offset to starting point
-                kminor_loc = interpolate2D(fminor(:,:,iflav,icol,ilay), kminor, minor_loc, &
-                                           jeta(:,iflav,icol,ilay), jtemp(icol,ilay))
-                tau_minor = kminor_loc * scaling
-                !$acc atomic update
-                tau(igpt,ilay,icol) = tau(igpt,ilay,icol) + tau_minor
-              enddo
+
+              tau_minor = 0._wp
+              iflav = gpt_flv(idx_tropo,igpt) ! eta interpolation depends on flavor
+              minor_loc = minor_start + (igpt - gptS) ! add offset to starting point
+              kminor_loc = interpolate2D(fminor(:,:,iflav,icol,ilay), kminor, minor_loc, &
+                                          jeta(:,iflav,icol,ilay), myjtemp)
+              tau_minor = kminor_loc * scaling
+
+              !$acc atomic update
+              tau(igpt,ilay,icol) = tau(igpt,ilay,icol) + tau_minor
             endif
-          endif
+
+          enddo
+
         enddo
       enddo
     enddo
@@ -550,7 +570,7 @@ contains
     real(wp) :: planck_function(nbnd,nlay+1,ncol)
     ! -----------------
 
-    !$acc enter data copyin(tlay,tlev,tsfc,fmajor,jeta,tropo,jtemp,jpress,gpoint_bands,pfracin,totplnk,gpoint_flavor,one)
+    !$acc enter data copyin(tlay,tlev,tsfc,fmajor,jeta,tropo,jtemp,jpress,gpoint_bands,pfracin,totplnk,gpoint_flavor)
     !$acc enter data create(sfc_src,lay_src,lev_src_inc,lev_src_dec)
     !$acc enter data create(pfrac,planck_function)
 
@@ -598,11 +618,16 @@ contains
     !
     ! Map to g-points
     !
+    ! Explicitly unroll a time-consuming loop here to increase instruction-level parallelism on a GPU
+    ! Helps to achieve higher bandwidth
+    !
     !$acc parallel loop collapse(3)
-    do igpt = 1, ngpt
+    do icol = 1, ncol, 2
       do ilay = 1, nlay
-        do icol = 1, ncol
-          lay_src(igpt,ilay,icol) = pfrac(igpt,ilay,icol) * planck_function(gpoint_bands(igpt),ilay,icol)
+        do igpt = 1, ngpt
+          lay_src(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay,icol)
+          if (icol < ncol) &
+          lay_src(igpt,ilay,icol+1) = pfrac(igpt,ilay,icol+1) * planck_function(gpoint_bands(igpt),ilay,icol+1)
         end do
       end do ! ilay
     end do ! icol
@@ -623,17 +648,23 @@ contains
     !
     ! Map to g-points
     !
+    ! Same unrolling as mentioned before
+    !
     !$acc parallel loop collapse(3)
-    do igpt = 1, ngpt
+    do icol = 1, ncol, 2
       do ilay = 1, nlay
-        do icol = 1, ncol
-          lev_src_dec(igpt,ilay,icol) = pfrac(igpt,ilay,icol) * planck_function(gpoint_bands(igpt),ilay,  icol)
-          lev_src_inc(igpt,ilay,icol) = pfrac(igpt,ilay,icol) * planck_function(gpoint_bands(igpt),ilay+1,icol)
+        do igpt = 1, ngpt
+          lev_src_dec(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay,  icol  )
+          lev_src_inc(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay+1,icol  )
+          if (icol < ncol) then
+          lev_src_dec(igpt,ilay,icol+1) = pfrac(igpt,ilay,icol+1) * planck_function(gpoint_bands(igpt),ilay,  icol+1)
+          lev_src_inc(igpt,ilay,icol+1) = pfrac(igpt,ilay,icol+1) * planck_function(gpoint_bands(igpt),ilay+1,icol+1)
+          end if
         end do
       end do ! ilay
     end do ! icol
 
-    !$acc exit data delete(tlay,tlev,tsfc,fmajor,jeta,tropo,jtemp,jpress,gpoint_bands,pfracin,totplnk,gpoint_flavor,one)
+    !$acc exit data delete(tlay,tlev,tsfc,fmajor,jeta,tropo,jtemp,jpress,gpoint_bands,pfracin,totplnk,gpoint_flavor)
     !$acc exit data delete(pfrac,planck_function)
     !$acc exit data copyout(sfc_src,lay_src,lev_src_inc,lev_src_dec)
 
@@ -722,15 +753,29 @@ contains
     real(wp), dimension(ngpt,nlay,ncol), intent(in   ) :: tau_abs, tau_rayleigh
     real(wp), dimension(ncol,nlay,ngpt), intent(inout) :: tau, ssa, g ! inout because components are allocated
     ! -----------------------
-    integer  :: icol, ilay, igpt
+    integer  :: icol, ilay, igpt,  icol0, igpt0, icdiff, igdiff
     real(wp) :: t
+    integer, parameter :: tile = 32
     ! -----------------------
-    !$acc parallel loop collapse(3) &
-    !$acc&     copy(tau, ssa, g) &
-    !$acc&     copyin(tau_rayleigh,tau_abs)
-    do icol = 1, ncol
+    !$acc data copy(tau, ssa, g)                 &
+    !$acc      copyin(tau_rayleigh, tau_abs)
+
+    ! We are using blocking memory accesses here to improve performance
+    !  of the transpositions. See also comments in mo_reorder_kernels.F90
+    !
+    !$acc parallel default(none) vector_length(tile*tile)
+    !$acc loop gang collapse(3)
       do ilay = 1, nlay
-        do igpt = 1, ngpt
+      do icol0 = 1, ncol, tile
+        do igpt0 = 1, ngpt, tile
+
+          !$acc loop vector collapse(2)
+          do igdiff = 0, tile-1
+            do icdiff = 0, tile-1
+              icol = icol0 + icdiff
+              igpt = igpt0 + igdiff
+              if (icol > ncol .or. igpt > ngpt) cycle
+
            t = tau_abs(igpt,ilay,icol) + tau_rayleigh(igpt,ilay,icol)
            tau(icol,ilay,igpt) = t
            g  (icol,ilay,igpt) = 0._wp
@@ -739,9 +784,15 @@ contains
            else
              ssa(icol,ilay,igpt) = 0._wp
            end if
+
+            end do
+          end do
+
         end do
       end do
     end do
+    !$acc end parallel
+    !$acc end data
   end subroutine combine_and_reorder_2str
   ! ----------------------------------------------------------
   !

--- a/rrtmgp/kernels/mo_reorder_kernels.F90
+++ b/rrtmgp/kernels/mo_reorder_kernels.F90
@@ -24,18 +24,42 @@ contains
     real(wp), dimension(d1, d2, d3), intent( in) :: array_in
     real(wp), dimension(d3, d1, d2), intent(out) :: array_out
 
-    integer :: i1, i2, i3
+    integer :: i1, i2, i3, i10, i30, i1diff, i3diff
+    integer, parameter :: tile = 32
 
-    !$acc parallel loop collapse(3) &
-    !$acc&     copyout(array_out(:d3,:d1,:d2)) &
-    !$acc&     copyin(array_in(:d1,:d2,:d3))
+    ! This kernel uses blocking to speed-up the transposition
+    ! We read the data block by block (three outer loops)
+    !  such that a block fits into fastest cache and the memory reads
+    !  are resolved in the cache. The writes are contiguous here, so
+    !  shouldn't be a problem.
+    !  Tile size of 32x32 is empirical: big enough to read from the whole
+    !  cache line, and small enough to fit into cache. Other numbers
+    !  may give slightly better performance on different hardware.
+    !
+    !$acc parallel vector_length(tile*tile) &
+    !$acc&     copyout(array_out) &
+    !$acc&     copyin(array_in)
+    !$acc loop gang collapse(3)
     do i2 = 1, d2
-      do i1 = 1, d1
-        do i3 = 1, d3
-          array_out(i3,i1,i2) = array_in(i1,i2,i3)
+      do i10 = 1, d1, tile
+        do i30 = 1, d3, tile
+
+          !$acc loop vector collapse(2)
+          do i1diff = 0, tile-1
+            do i3diff = 0, tile-1
+              i1 = i10 + i1diff
+              i3 = i30 + i3diff
+              if (i1 > d1 .or. i3 > d3) cycle
+              
+              array_out(i3,i1,i2) = array_in(i1,i2,i3)
+            end do
+          end do
+
         end do
       end do
     end do
+    !$acc end parallel
+
   end subroutine reorder_123x312_kernel
   ! ----------------------------------------------------------------------------
   subroutine reorder_123x321_kernel(d1, d2, d3, array_in, array_out) & 
@@ -44,18 +68,36 @@ contains
     real(wp), dimension(d1, d2, d3), intent( in) :: array_in
     real(wp), dimension(d3, d2, d1), intent(out) :: array_out
 
-    integer :: i1, i2, i3
+    integer :: i1, i2, i3, i10, i30, i1diff, i3diff, idiff
+    integer, parameter :: tile = 32
 
-    !$acc parallel loop collapse(3) &
-    !$acc&     copyout(array_out(:d3,:d2,:d1)) &
-    !$acc&     copyin(array_in(:d1,:d2,:d3))
-    do i1 = 1, d1
-      do i2 = 1, d2
-        do i3 = 1, d3
-          array_out(i3,i2,i1) = array_in(i1,i2,i3)
+    ! See the comment above
+    !
+    !$acc parallel vector_length(tile*tile) &
+    !$acc&     copyout(array_out) &
+    !$acc&     copyin(array_in)
+    !$acc loop gang collapse(3) 
+    ! private(cache(:,:))
+    do i2 = 1, d2
+      do i10 = 1, d1, tile
+        do i30 = 1, d3, tile
+
+          !$acc loop vector collapse(2)
+          do i1diff = 0, tile-1
+            do i3diff = 0, tile-1
+              i1 = i10 + i1diff
+              i3 = i30 + i3diff
+              if (i1 > d1 .or. i3 > d3) cycle
+              
+              array_out(i3,i2,i1) = array_in(i1,i2,i3)
+            end do
+          end do
+          
         end do
       end do
     end do
+    !$acc end parallel
+
   end subroutine reorder_123x321_kernel
   ! ----------------------------------------------------------------------------
 end module mo_reorder_kernels

--- a/rte/kernels-openacc/mo_rte_solver_kernels.F90
+++ b/rte/kernels-openacc/mo_rte_solver_kernels.F90
@@ -87,7 +87,10 @@ contains
     real(wp), dimension(:,:,:), pointer :: lev_source_up, lev_source_dn ! Mapping increasing/decreasing indicies to up/down
 
     real(wp), parameter :: pi = acos(-1._wp)
-    integer             :: icol, ilev, igpt, top_level
+    integer             :: icol, ilev, igpt, top_level, ilay
+
+    real(wp)            :: fact
+    real(wp), parameter :: tau_thresh = sqrt(epsilon(tau_loc))
     ! ------------------------------------
 
 
@@ -110,23 +113,6 @@ contains
     !$acc enter data create(tau_loc,trans,source_dn,source_up,source_sfc,sfc_albedo,radn_up)
     !$acc enter data attach(lev_source_up,lev_source_dn)
 
-    ! NOTE: This kernel produces small differences between GPU and CPU
-    ! implementations on Ascent with PGI, we assume due to floating point
-    ! differences in the exp() function. These differences are small in the
-    ! RFMIP test case (10^-6).
-    !$acc parallel loop collapse(3)
-    do igpt = 1, ngpt
-      do ilev = 1, nlay
-        do icol = 1, ncol
-          !
-          ! Optical path and transmission, used in source function and transport calculations
-          !
-          tau_loc(icol,ilev,igpt) = tau(icol,ilev,igpt)*D(icol,igpt)
-          trans  (icol,ilev,igpt) = exp(-tau_loc(icol,ilev,igpt))
-        end do
-      end do
-    end do
-
     !$acc parallel loop collapse(2)
     do igpt = 1, ngpt
       do icol = 1, ncol
@@ -143,12 +129,27 @@ contains
       end do
     end do
 
-    !
-    ! Source function for diffuse radiation
-    !
-    call lw_source_noscat(ncol, nlay, ngpt, &
-                          lay_source, lev_source_up, lev_source_dn, &
-                          tau_loc, trans, source_dn, source_up)
+    ! NOTE: This kernel produces small differences between GPU and CPU
+    ! implementations on Ascent with PGI, we assume due to floating point
+    ! differences in the exp() function. These differences are small in the
+    ! RFMIP test case (10^-6).
+    !$acc parallel loop collapse(3)
+    do igpt = 1, ngpt
+      do ilay = 1, nlay
+        do icol = 1, ncol
+          !
+          ! Optical path and transmission, used in source function and transport calculations
+          !
+          tau_loc(icol,ilay,igpt) = tau(icol,ilay,igpt)*D(icol,igpt)
+          trans  (icol,ilay,igpt) = exp(-tau_loc(icol,ilay,igpt))
+
+          call lw_source_noscat_stencil(ncol, nlay, ngpt, icol, ilay, igpt,        &
+                                        lay_source, lev_source_up, lev_source_dn,  &
+                                        tau_loc, trans,                            &
+                                        source_dn, source_up)
+        end do
+      end do
+    end do
 
     !
     ! Transport
@@ -356,55 +357,55 @@ contains
   !   Extinction-only i.e. solar direct beam
   !
   ! -------------------------------------------------------------------------------------------------
-    subroutine sw_solver_noscat(ncol, nlay, ngpt, &
-                                top_at_1, tau, mu0, flux_dir) bind (C, name="sw_solver_noscat")
-      integer,                    intent(in   ) :: ncol, nlay, ngpt ! Number of columns, layers, g-points
-      logical(wl),                intent(in   ) :: top_at_1
-      real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: tau          ! Absorption optical thickness []
-      real(wp), dimension(ncol            ), intent(in   ) :: mu0          ! cosine of solar zenith angle
-      real(wp), dimension(ncol,nlay+1,ngpt), intent(inout) :: flux_dir     ! Direct-beam flux, spectral [W/m2]
-                                                                           ! Top level must contain incident flux boundary condition
-      integer :: icol, ilev, igpt
-      real(wp) :: mu0_inv(ncol)
-      ! ------------------------------------
-      ! ------------------------------------
-      !$acc enter data copyin(tau, mu0) create(mu0_inv, flux_dir)
-      !$acc parallel loop
-      do icol = 1, ncol
-        mu0_inv(icol) = 1._wp/mu0(icol)
-      enddo
-      ! Indexing into arrays for upward and downward propagation depends on the vertical
-      !   orientation of the arrays (whether the domain top is at the first or last index)
-      ! We write the loops out explicitly so compilers will have no trouble optimizing them.
+  subroutine sw_solver_noscat(ncol, nlay, ngpt, &
+                              top_at_1, tau, mu0, flux_dir) bind (C, name="sw_solver_noscat")
+    integer,                    intent(in   ) :: ncol, nlay, ngpt ! Number of columns, layers, g-points
+    logical(wl),                intent(in   ) :: top_at_1
+    real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: tau          ! Absorption optical thickness []
+    real(wp), dimension(ncol            ), intent(in   ) :: mu0          ! cosine of solar zenith angle
+    real(wp), dimension(ncol,nlay+1,ngpt), intent(inout) :: flux_dir     ! Direct-beam flux, spectral [W/m2]
+                                                                          ! Top level must contain incident flux boundary condition
+    integer :: icol, ilev, igpt
+    real(wp) :: mu0_inv(ncol)
+    ! ------------------------------------
+    ! ------------------------------------
+    !$acc enter data copyin(tau, mu0) create(mu0_inv, flux_dir)
+    !$acc parallel loop
+    do icol = 1, ncol
+      mu0_inv(icol) = 1._wp/mu0(icol)
+    enddo
+    ! Indexing into arrays for upward and downward propagation depends on the vertical
+    !   orientation of the arrays (whether the domain top is at the first or last index)
+    ! We write the loops out explicitly so compilers will have no trouble optimizing them.
 
-      ! Downward propagation
-      if(top_at_1) then
-        ! For the flux at this level, what was the previous level, and which layer has the
-        !   radiation just passed through?
-        ! layer index = level index - 1
-        ! previous level is up (-1)
-        !$acc parallel loop collapse(2)
-        do igpt = 1, ngpt
-          do icol = 1, ncol
-            do ilev = 2, nlay+1
-              flux_dir(icol,ilev,igpt) = flux_dir(icol,ilev-1,igpt) * exp(-tau(icol,ilev,igpt)*mu0_inv(icol))
-            end do
+    ! Downward propagation
+    if(top_at_1) then
+      ! For the flux at this level, what was the previous level, and which layer has the
+      !   radiation just passed through?
+      ! layer index = level index - 1
+      ! previous level is up (-1)
+      !$acc parallel loop collapse(2)
+      do igpt = 1, ngpt
+        do icol = 1, ncol
+          do ilev = 2, nlay+1
+            flux_dir(icol,ilev,igpt) = flux_dir(icol,ilev-1,igpt) * exp(-tau(icol,ilev,igpt)*mu0_inv(icol))
           end do
         end do
-      else
-        ! layer index = level index
-        ! previous level is up (+1)
-        !$acc parallel loop collapse(2)
-        do igpt = 1, ngpt
-          do icol = 1, ncol
-            do ilev = nlay, 1, -1
-              flux_dir(icol,ilev,igpt) = flux_dir(icol,ilev+1,igpt) * exp(-tau(icol,ilev,igpt)*mu0_inv(icol))
-            end do
+      end do
+    else
+      ! layer index = level index
+      ! previous level is up (+1)
+      !$acc parallel loop collapse(2)
+      do igpt = 1, ngpt
+        do icol = 1, ncol
+          do ilev = nlay, 1, -1
+            flux_dir(icol,ilev,igpt) = flux_dir(icol,ilev+1,igpt) * exp(-tau(icol,ilev,igpt)*mu0_inv(icol))
           end do
         end do
-      end if
-      !$acc exit data delete(tau, mu0, mu0_inv) copyout(flux_dir)
-    end subroutine sw_solver_noscat
+      end do
+    end if
+    !$acc exit data delete(tau, mu0, mu0_inv) copyout(flux_dir)
+  end subroutine sw_solver_noscat
   ! -------------------------------------------------------------------------------------------------
   !
   ! Shortwave two-stream calculation:
@@ -413,109 +414,138 @@ contains
   !   transport
   !
   ! -------------------------------------------------------------------------------------------------
-    subroutine sw_solver_2stream (ncol, nlay, ngpt, top_at_1, &
-                                  tau, ssa, g, mu0,           &
-                                  sfc_alb_dir, sfc_alb_dif,   &
-                                  flux_up, flux_dn, flux_dir) bind (C, name="sw_solver_2stream")
-      integer,                               intent(in   ) :: ncol, nlay, ngpt ! Number of columns, layers, g-points
-      logical(wl),                           intent(in   ) :: top_at_1
-      real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: tau, &  ! Optical thickness,
-                                                              ssa, &  ! single-scattering albedo,
-                                                              g       ! asymmetry parameter []
-      real(wp), dimension(ncol            ), intent(in   ) :: mu0     ! cosine of solar zenith angle
-      real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_alb_dir, sfc_alb_dif
-                                                                    ! Spectral albedo of surface to direct and diffuse radiation
-      real(wp), dimension(ncol,nlay+1,ngpt), &
-                                             intent(  out) :: flux_up ! Fluxes [W/m2]
-      real(wp), dimension(ncol,nlay+1,ngpt), &                        ! Downward fluxes contain boundary conditions
-                                             intent(inout) :: flux_dn, flux_dir
-      ! -------------------------------------------
-      integer :: icol, ilay, igpt
-      real(wp), dimension(ncol,nlay,ngpt) :: Rdif, Tdif, Rdir, Tdir, Tnoscat
-      real(wp), dimension(ncol,nlay,ngpt) :: source_up, source_dn
-      real(wp), dimension(ncol     ,ngpt) :: source_srf
-      ! ------------------------------------
-      !
-      ! Cell properties: transmittance and reflectance for direct and diffuse radiation
-      !
-      !$acc enter data copyin(tau, ssa, g, mu0, sfc_alb_dir, sfc_alb_dif, flux_dn, flux_dir)
-      !$acc enter data create(Rdif, Tdif, Rdir, Tdir, Tnoscat, source_up, source_dn, source_srf, flux_up)
-      call sw_two_stream(ncol, nlay, ngpt, mu0, &
-                         tau , ssa , g   ,      &
-                         Rdif, Tdif, Rdir, Tdir, Tnoscat)
-      call sw_source_2str(ncol, nlay, ngpt, top_at_1,       &
-                          Rdir, Tdir, Tnoscat, sfc_alb_dir, &
-                          source_up, source_dn, source_srf, flux_dir)
-      call adding(ncol, nlay, ngpt, top_at_1,   &
-                  sfc_alb_dif, Rdif, Tdif,      &
-                  source_dn, source_up, source_srf, flux_up, flux_dn)
-      !
-      ! adding computes only diffuse flux; flux_dn is total
-      !
-      !$acc  parallel loop collapse(3)
-      do igpt = 1, ngpt
-        do ilay = 1, nlay+1
-          do icol = 1, ncol
-            flux_dn(icol,ilay,igpt) = flux_dn(icol,ilay,igpt) + flux_dir(icol,ilay,igpt)
-          end do
+  subroutine sw_solver_2stream (ncol, nlay, ngpt, top_at_1, &
+                                tau, ssa, g, mu0,           &
+                                sfc_alb_dir, sfc_alb_dif,   &
+                                flux_up, flux_dn, flux_dir) bind (C, name="sw_solver_2stream")
+    integer,                               intent(in   ) :: ncol, nlay, ngpt ! Number of columns, layers, g-points
+    logical(wl),                           intent(in   ) :: top_at_1
+    real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: tau, &  ! Optical thickness,
+                                                            ssa, &  ! single-scattering albedo,
+                                                            g       ! asymmetry parameter []
+    real(wp), dimension(ncol            ), intent(in   ) :: mu0     ! cosine of solar zenith angle
+    real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_alb_dir, sfc_alb_dif
+                                                                  ! Spectral albedo of surface to direct and diffuse radiation
+    real(wp), dimension(ncol,nlay+1,ngpt), &
+                                            intent(  out) :: flux_up ! Fluxes [W/m2]
+    real(wp), dimension(ncol,nlay+1,ngpt), &                        ! Downward fluxes contain boundary conditions
+                                            intent(inout) :: flux_dn, flux_dir
+    ! -------------------------------------------
+    integer :: icol, ilay, igpt
+    real(wp), dimension(ncol,nlay,ngpt) :: Rdif, Tdif, Rdir, Tdir, Tnoscat
+    real(wp), dimension(ncol,nlay,ngpt) :: source_up, source_dn
+    real(wp), dimension(ncol     ,ngpt) :: source_srf
+    ! ------------------------------------
+    !
+    ! Cell properties: transmittance and reflectance for direct and diffuse radiation
+    !
+    !$acc enter data copyin(tau, ssa, g, mu0, sfc_alb_dir, sfc_alb_dif, flux_dn, flux_dir)
+    !$acc enter data create(Rdif, Tdif, Rdir, Tdir, Tnoscat, source_up, source_dn, source_srf, flux_up)
+    call sw_two_stream(ncol, nlay, ngpt, mu0, &
+                        tau , ssa , g   ,      &
+                        Rdif, Tdif, Rdir, Tdir, Tnoscat)
+    call sw_source_2str(ncol, nlay, ngpt, top_at_1,       &
+                        Rdir, Tdir, Tnoscat, sfc_alb_dir, &
+                        source_up, source_dn, source_srf, flux_dir)
+    call adding(ncol, nlay, ngpt, top_at_1,   &
+                sfc_alb_dif, Rdif, Tdif,      &
+                source_dn, source_up, source_srf, flux_up, flux_dn)
+    !
+    ! adding computes only diffuse flux; flux_dn is total
+    !
+    !$acc  parallel loop collapse(3)
+    do igpt = 1, ngpt
+      do ilay = 1, nlay+1
+        do icol = 1, ncol
+          flux_dn(icol,ilay,igpt) = flux_dn(icol,ilay,igpt) + flux_dir(icol,ilay,igpt)
         end do
       end do
-      !$acc exit data copyout(flux_up, flux_dn, flux_dir)
-      !$acc exit data delete (tau, ssa, g, mu0, sfc_alb_dir, sfc_alb_dif, Rdif, Tdif, Rdir, Tdir, Tnoscat, source_up, source_dn, source_srf)
+    end do
+    !$acc exit data copyout(flux_up, flux_dn, flux_dir)
+    !$acc exit data delete (tau, ssa, g, mu0, sfc_alb_dir, sfc_alb_dif, Rdif, Tdif, Rdir, Tdir, Tnoscat, source_up, source_dn, source_srf)
 
-    end subroutine sw_solver_2stream
+  end subroutine sw_solver_2stream
 
-    ! -------------------------------------------------------------------------------------------------
+  ! -------------------------------------------------------------------------------------------------
+  !
+  !   Lower-level longwave kernels
+  !
+  ! ---------------------------------------------------------------
+  !
+  ! Compute LW source function for upward and downward emission at levels using linear-in-tau assumption
+  ! See Clough et al., 1992, doi: 10.1029/92JD01419, Eq 13
+  ! This routine implements point-wise stencil, and has to be called in a loop
+  !
+  ! ---------------------------------------------------------------
+  subroutine lw_source_noscat_stencil(ncol, nlay, ngpt, icol, ilay, igpt,                   &
+                                      lay_source, lev_source_up, lev_source_dn, tau, trans, &
+                                      source_dn, source_up)
+    !$acc routine seq
     !
-    !   Lower-level longwave kernels
-    !
-    ! ---------------------------------------------------------------
-    !
-    ! Compute LW source function for upward and downward emission at levels using linear-in-tau assumption
-    ! See Clough et al., 1992, doi: 10.1029/92JD01419, Eq 13
-    !
-    ! ---------------------------------------------------------------
-    subroutine lw_source_noscat(ncol, nlay, ngpt, lay_source, lev_source_up, lev_source_dn, tau, trans, &
-                                source_dn, source_up) bind(C, name="lw_source_noscat")
-      integer,                               intent(in) :: ncol, nlay, ngpt
-      real(wp), dimension(ncol, nlay, ngpt), intent(in) :: lay_source, & ! Planck source at layer center
+    integer,                               intent(in)   :: ncol, nlay, ngpt
+    integer,                               intent(in)   :: icol, ilay, igpt ! Working point coordinates
+    real(wp), dimension(ncol, nlay, ngpt), intent(in)   :: lay_source,    & ! Planck source at layer center
                                                            lev_source_up, & ! Planck source at levels (layer edges),
                                                            lev_source_dn, & !   increasing/decreasing layer index
-                                                           tau,        & ! Optical path (tau/mu)
-                                                           trans         ! Transmissivity (exp(-tau))
-      real(wp), dimension(ncol, nlay, ngpt), intent(out):: source_dn, source_up
-                                                                     ! Source function at layer edges
-                                                                     ! Down at the bottom of the layer, up at the top
-      ! --------------------------------
-      integer             :: icol, ilay, igpt
-      real(wp)            :: fact
-      real(wp), parameter :: tau_thresh = sqrt(epsilon(tau))
-      ! ---------------------------------------------------------------
-      ! ---------------------------------------------------------------
-      !$acc  parallel loop collapse(3)
-      do igpt = 1, ngpt
-        do ilay = 1, nlay
-          do icol = 1, ncol
-          !
-          ! Weighting factor. Use 2nd order series expansion when rounding error (~tau^2)
-          !   is of order epsilon (smallest difference from 1. in working precision)
-          !   Thanks to Peter Blossey
-          !
-          fact = merge((1._wp - trans(icol,ilay,igpt))/tau(icol,ilay,igpt) - trans(icol,ilay,igpt), &
-                       tau(icol,ilay,igpt) * ( 0.5_wp - 1._wp/3._wp*tau(icol,ilay,igpt) ), &
-                       tau(icol,ilay,igpt) > tau_thresh)
-          !
-          ! Equation below is developed in Clough et al., 1992, doi:10.1029/92JD01419, Eq 13
-          !
-          source_dn(icol,ilay,igpt) = (1._wp - trans(icol,ilay,igpt)) * lev_source_dn(icol,ilay,igpt) + &
-                                  2._wp * fact * (lay_source(icol,ilay, igpt) - lev_source_dn(icol,ilay,igpt))
-          source_up(icol,ilay,igpt) = (1._wp - trans(icol,ilay,igpt)) * lev_source_up(icol,ilay,igpt) + &
-                                  2._wp * fact * (lay_source(icol,ilay,igpt) - lev_source_up(icol,ilay,igpt))
-          end do
+                                                           tau,           & ! Optical path (tau/mu)
+                                                           trans            ! Transmissivity (exp(-tau))
+    real(wp), dimension(ncol, nlay, ngpt), intent(inout):: source_dn, source_up
+                                                                  ! Source function at layer edges
+                                                                  ! Down at the bottom of the layer, up at the top
+    ! --------------------------------
+    real(wp), parameter  :: tau_thresh = sqrt(epsilon(tau))
+    real(wp)             :: fact
+
+    ! ---------------------------------------------------------------
+    !
+    ! Weighting factor. Use 2nd order series expansion when rounding error (~tau^2)
+    !   is of order epsilon (smallest difference from 1. in working precision)
+    !   Thanks to Peter Blossey
+    !
+    fact = merge((1._wp - trans(icol,ilay,igpt))/tau(icol,ilay,igpt) - trans(icol,ilay,igpt), &
+                          tau(icol,ilay,igpt) * ( 0.5_wp - 1._wp/3._wp*tau(icol,ilay,igpt) ), &
+                          tau(icol,ilay,igpt) > tau_thresh)
+    !
+    ! Equation below is developed in Clough et al., 1992, doi:10.1029/92JD01419, Eq 13
+    !
+    source_dn(icol,ilay,igpt) = (1._wp - trans(icol,ilay,igpt)) * lev_source_dn(icol,ilay,igpt) + &
+            2._wp * fact * (lay_source(icol,ilay,igpt) - lev_source_dn(icol,ilay,igpt))
+    source_up(icol,ilay,igpt) = (1._wp - trans(icol,ilay,igpt)) * lev_source_up(icol,ilay,igpt) + &
+            2._wp * fact * (lay_source(icol,ilay,igpt) - lev_source_up(icol,ilay,igpt))
+
+  end subroutine lw_source_noscat_stencil
+  ! ---------------------------------------------------------------
+  !
+  ! Driver function to compute LW source function for upward and downward emission
+  !
+  ! ---------------------------------------------------------------
+  subroutine lw_source_noscat(ncol, nlay, ngpt, lay_source, lev_source_up, lev_source_dn, tau, trans, &
+                              source_dn, source_up) bind(C, name="lw_source_noscat")
+    integer,                               intent(in) :: ncol, nlay, ngpt
+    real(wp), dimension(ncol, nlay, ngpt), intent(in) :: lay_source,    & ! Planck source at layer center
+                                                         lev_source_up, & ! Planck source at levels (layer edges),
+                                                         lev_source_dn, & !   increasing/decreasing layer index
+                                                         tau,           & ! Optical path (tau/mu)
+                                                         trans            ! Transmissivity (exp(-tau))
+    real(wp), dimension(ncol, nlay, ngpt), intent(out):: source_dn, source_up
+                                                                ! Source function at layer edges
+                                                                ! Down at the bottom of the layer, up at the top
+    ! --------------------------------
+    integer :: icol, ilay, igpt
+    ! ---------------------------------------------------------------
+    !$acc  parallel loop collapse(3)
+    do igpt = 1, ngpt
+      do ilay = 1, nlay
+        do icol = 1, ncol
+          call lw_source_noscat_stencil(ncol, nlay, ngpt, icol, ilay, igpt,        &
+                                        lay_source, lev_source_up, lev_source_dn,  &
+                                        tau, trans,                                &
+                                        source_dn, source_up)
         end do
       end do
+    end do
 
-    end subroutine lw_source_noscat
+  end subroutine lw_source_noscat
   ! ---------------------------------------------------------------
   !
   ! Longwave no-scattering transport
@@ -962,12 +992,17 @@ contains
     real(wp), dimension(ncol,nlay+1,ngpt), intent(inout) :: flux_dn
     ! ------------------
     integer :: icol, ilev, igpt
-    real(wp), dimension(nlay+1) :: albedo, &  ! reflectivity to diffuse radiation below this level
+
+    ! These arrays could be private per thread in OpenACC, with 1 dimension of size nlay (or nlay+1)
+    ! However, current PGI (19.4) has a bug preventing it from properly handling such private arrays.
+    ! So we explicitly create the temporary arrays of size nlay(+1) per each of the ncol*ngpt elements
+    ! 
+    real(wp), dimension(ncol,nlay+1,ngpt) :: albedo, &  ! reflectivity to diffuse radiation below this level
                                               ! alpha in SH08
                                    src        ! source of diffuse upwelling radiation from emission or
                                               ! scattering of direct beam
                                               ! G in SH08
-    real(wp), dimension(nlay  ) :: denom      ! beta in SH08
+    real(wp), dimension(ncol,nlay  ,ngpt) :: denom      ! beta in SH08
     ! ------------------
     ! ---------------------------------
     !
@@ -977,107 +1012,96 @@ contains
     !
     !$acc enter data copyin(albedo_sfc, rdif, tdif, src_dn, src_up, src_sfc, flux_dn)
     !$acc enter data create(flux_up, albedo, src, denom)
+
     if(top_at_1) then
-#ifdef __PGI
-      !$acc parallel loop
-#else
-      !$acc parallel loop collapse(2) private(albedo, src, denom)
-#endif
+      !$acc parallel loop gang vector collapse(2)
       do igpt = 1, ngpt
-#ifdef __PGI
-        !$acc loop private(albedo, src, denom)
-#endif
         do icol = 1, ncol
           ilev = nlay + 1
           ! Albedo of lowest level is the surface albedo...
-          albedo(ilev)  = albedo_sfc(icol,igpt)
+          albedo(icol,ilev,igpt)  = albedo_sfc(icol,igpt)
           ! ... and source of diffuse radiation is surface emission
-          src(ilev) = src_sfc(icol,igpt)
+          src(icol,ilev,igpt) = src_sfc(icol,igpt)
 
           !
           ! From bottom to top of atmosphere --
           !   compute albedo and source of upward radiation
           !
           do ilev = nlay, 1, -1
-            denom(ilev) = 1._wp/(1._wp - rdif(icol,ilev,igpt)*albedo(ilev+1))                 ! Eq 10
-            albedo(ilev) = rdif(icol,ilev,igpt) + &
-                           tdif(icol,ilev,igpt)*tdif(icol,ilev,igpt) * albedo(ilev+1) * denom(ilev) ! Equation 9
+            denom(icol,ilev,igpt) = 1._wp/(1._wp - rdif(icol,ilev,igpt)*albedo(icol,ilev+1,igpt))    ! Eq 10
+            albedo(icol,ilev,igpt) = rdif(icol,ilev,igpt) + &
+                  tdif(icol,ilev,igpt)*tdif(icol,ilev,igpt) * albedo(icol,ilev+1,igpt) * denom(icol,ilev,igpt) ! Equation 9
             !
             ! Equation 11 -- source is emitted upward radiation at top of layer plus
             !   radiation emitted at bottom of layer,
             !   transmitted through the layer and reflected from layers below (tdiff*src*albedo)
             !
-            src(ilev) =  src_up(icol, ilev, igpt) + &
-                           tdif(icol,ilev,igpt) * denom(ilev) *       &
-                             (src(ilev+1) + albedo(ilev+1)*src_dn(icol,ilev,igpt))
+            src(icol,ilev,igpt) =  src_up(icol, ilev, igpt) + &
+                           tdif(icol,ilev,igpt) * denom(icol,ilev,igpt) *       &
+                             (src(icol,ilev+1,igpt) + albedo(icol,ilev+1,igpt)*src_dn(icol,ilev,igpt))
           end do
 
           ! Eq 12, at the top of the domain upwelling diffuse is due to ...
           ilev = 1
-          flux_up(icol,ilev,igpt) = flux_dn(icol,ilev,igpt) * albedo(ilev) + & ! ... reflection of incident diffuse and
-                                    src(ilev)                                  ! emission from below
+          flux_up(icol,ilev,igpt) = flux_dn(icol,ilev,igpt) * albedo(icol,ilev,igpt) + & ! ... reflection of incident diffuse and
+                                    src(icol,ilev,igpt)                                  ! emission from below
 
           !
           ! From the top of the atmosphere downward -- compute fluxes
           !
           do ilev = 2, nlay+1
             flux_dn(icol,ilev,igpt) = (tdif(icol,ilev-1,igpt)*flux_dn(icol,ilev-1,igpt) + &  ! Equation 13
-                               rdif(icol,ilev-1,igpt)*src(ilev) +       &
-                               src_dn(icol,ilev-1,igpt)) * denom(ilev-1)
-            flux_up(icol,ilev,igpt) = flux_dn(icol,ilev,igpt) * albedo(ilev) + & ! Equation 12
-                              src(ilev)
+                               rdif(icol,ilev-1,igpt)*src(icol,ilev,igpt) +       &
+                               src_dn(icol,ilev-1,igpt)) * denom(icol,ilev-1,igpt)
+            flux_up(icol,ilev,igpt) = flux_dn(icol,ilev,igpt) * albedo(icol,ilev,igpt) + & ! Equation 12
+                              src(icol,ilev,igpt)
           end do
         end do
       end do
+      
     else
-#ifdef __PGI
-      !$acc parallel loop
-#else
-      !$acc parallel loop collapse(2) private(albedo, src, denom)
-#endif
+
+      !$acc parallel loop collapse(2)
       do igpt = 1, ngpt
-#ifdef __PGI
-        !$acc loop private(albedo, src, denom)
-#endif
         do icol = 1, ncol
           ilev = 1
           ! Albedo of lowest level is the surface albedo...
-          albedo(ilev)  = albedo_sfc(icol,igpt)
+          albedo(icol,ilev,igpt)  = albedo_sfc(icol,igpt)
           ! ... and source of diffuse radiation is surface emission
-          src(ilev) = src_sfc(icol,igpt)
+          src(icol,ilev,igpt) = src_sfc(icol,igpt)
 
           !
           ! From bottom to top of atmosphere --
           !   compute albedo and source of upward radiation
           !
           do ilev = 1, nlay
-            denom(ilev  ) = 1._wp/(1._wp - rdif(icol,ilev,igpt)*albedo(ilev))                ! Eq 10
-            albedo(ilev+1) = rdif(icol,ilev,igpt) + &
-                               tdif(icol,ilev,igpt)*tdif(icol,ilev,igpt) * albedo(ilev) * denom(ilev) ! Equation 9
+            denom (icol,ilev  ,igpt) = 1._wp/(1._wp - rdif(icol,ilev,igpt)*albedo(icol,ilev,igpt))                ! Eq 10
+            albedo(icol,ilev+1,igpt) = rdif(icol,ilev,igpt) + &
+                               tdif(icol,ilev,igpt)*tdif(icol,ilev,igpt) * albedo(icol,ilev,igpt) * denom(icol,ilev,igpt) ! Equation 9
             !
             ! Equation 11 -- source is emitted upward radiation at top of layer plus
             !   radiation emitted at bottom of layer,
             !   transmitted through the layer and reflected from layers below (tdiff*src*albedo)
             !
-            src(ilev+1) =  src_up(icol, ilev, igpt) +  &
-                             tdif(icol,ilev,igpt) * denom(ilev) *       &
-                             (src(ilev) + albedo(ilev)*src_dn(icol,ilev,igpt))
+            src(icol,ilev+1,igpt) =  src_up(icol, ilev, igpt) +  &
+                             tdif(icol,ilev,igpt) * denom(icol,ilev,igpt) *       &
+                             (src(icol,ilev,igpt) + albedo(icol,ilev,igpt)*src_dn(icol,ilev,igpt))
           end do
 
           ! Eq 12, at the top of the domain upwelling diffuse is due to ...
           ilev = nlay+1
-          flux_up(icol,ilev,igpt) = flux_dn(icol,ilev,igpt) * albedo(ilev) + & ! ... reflection of incident diffuse and
-                            src(ilev)                          ! scattering by the direct beam below
+          flux_up(icol,ilev,igpt) = flux_dn(icol,ilev,igpt) * albedo(icol,ilev,igpt) + & ! ... reflection of incident diffuse and
+                            src(icol,ilev,igpt)                          ! scattering by the direct beam below
 
           !
           ! From the top of the atmosphere downward -- compute fluxes
           !
           do ilev = nlay, 1, -1
             flux_dn(icol,ilev,igpt) = (tdif(icol,ilev,igpt)*flux_dn(icol,ilev+1,igpt) + &  ! Equation 13
-                               rdif(icol,ilev,igpt)*src(ilev) + &
-                               src_dn(icol, ilev, igpt)) * denom(ilev)
-            flux_up(icol,ilev,igpt) = flux_dn(icol,ilev,igpt) * albedo(ilev) + & ! Equation 12
-                              src(ilev)
+                               rdif(icol,ilev,igpt)*src(icol,ilev,igpt) + &
+                               src_dn(icol, ilev, igpt)) * denom(icol,ilev,igpt)
+            flux_up(icol,ilev,igpt) = flux_dn(icol,ilev,igpt) * albedo(icol,ilev,igpt) + & ! Equation 12
+                              src(icol,ilev,igpt)
 
           end do
         end do


### PR DESCRIPTION
Contributions from Dmitry Alexeev from Nvidia. Dramatically improves performance of clear-sky RFMIP standalone cases on GPUs. Fixes compiler bug in PGI related to private local variables. 

* tiling reorder, could still be improved by about 40%

* using kernels in the mo_util_array, faster and more compact

* constant shouldn't be explicitly allocated

* tile combine_and_reorder, almost full bandwidth now

* process several elements per thread in expensive kernels

* fix interpolation, use gang vector

* add another kernel for optical_depths_minor, only working in a special case (hopefully typical case). about 3x faster.

* avoid atomics in sum_broadband, 2.5x faster

* explicitly make private arrays stay in global memory, fixed possible errors and 8x faster due to collapsed loop

* fuse lw_source_noscat into lw_solver_noscat, faster by about 1ms on Piz Daint

* fixed subscript typo in denom

* fix out-of-bounds issue

* added comments about how the reorder kernels work

* introduce point-wise lw_source_noscat_stencil to express concepts separation while keeping fused loops

* added comments explaining bug workaround for adding routine

* fixed unrolled loop bounds and added comments

* removed unused variable

* added missing data deletion

* remove the default kernel in gas_optical_depths_minor, the optimized kernel can deal with variable number of g-points per band now