### PR TITLE
Adding regression testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,11 @@
 Makefile.libs
 Makefile.conf
 
-src/
+# Intel code coverage
+*.dyn
+*.dpi
+*.spi
+*.spl
+*.HTML
+*.html
+*.gif

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: required
 dist: xenial
 language: cpp
-env:
-  - RTE_KERNELS=""
-  - RTE_KERNELS="openacc"
 matrix:
   include:
+  - env:
+    - RTE_KERNELS=""
+    - RTE_KERNELS="openacc"
   - compiler: gcc # Using
     env:
     - FC=pgfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,49 +5,48 @@ language: cpp
 #env:
 #  - RTE_KERNELS=""
 #  - RTE_KERNELS="openacc"
-matrix:
-  include:
-  - compiler: gcc # Using
-    env:
-    - FC=pgfortran
-    - FCFLAGS="-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
-    - TEST_PGI=yes
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-        packages:
-          - gcc-8
-          - gfortran-8
-          - libnetcdf-dev
-  - compiler: gcc
-    env:
-    - FC=gfortran-9
-    - FCFLAGS="-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
-    - TEST_PGI=no
-    - NCHOME=/usr/
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-        packages:
-          - gcc-9
-          - gfortran-9
-          - libnetcdf-dev
-  - compiler: gcc
-    env:
-    - FC=gfortran-8
-    - FCFLAGS="-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
-    - TEST_PGI=no
-    - NCHOME=/usr/
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-        packages:
-          - gcc-8
-          - gfortran-8
-          - libnetcdf-dev
+include:
+- compiler: gcc # Using
+  env:
+  - FC=pgfortran
+  - FCFLAGS="-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+  - TEST_PGI=yes
+  addons:
+    apt:
+      sources:
+        - ubuntu-toolchain-r-test
+      packages:
+        - gcc-8
+        - gfortran-8
+        - libnetcdf-dev
+- compiler: gcc
+  env:
+  - FC=gfortran-9
+  - FCFLAGS="-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
+  - TEST_PGI=no
+  - NCHOME=/usr/
+  addons:
+    apt:
+      sources:
+        - ubuntu-toolchain-r-test
+      packages:
+        - gcc-9
+        - gfortran-9
+        - libnetcdf-dev
+- compiler: gcc
+  env:
+  - FC=gfortran-8
+  - FCFLAGS="-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
+  - TEST_PGI=no
+  - NCHOME=/usr/
+  addons:
+    apt:
+      sources:
+        - ubuntu-toolchain-r-test
+      packages:
+        - gcc-8
+        - gfortran-8
+        - libnetcdf-dev
 # cache:
 #   timeout: 1000
 #   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
   - compiler: gcc
     env:
     - FC=gfortran-9
-    - FCFLAGS="-ffree-line-length-none -m64 -std=f2003 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
+    - FCFLAGS="-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
     - TEST_PGI=no
     - NCHOME=/usr/
     addons:
@@ -37,7 +37,7 @@ matrix:
   - compiler: gcc
     env:
     - FC=gfortran-8
-    - FCFLAGS="-ffree-line-length-none -m64 -std=f2003 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
+    - FCFLAGS="-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
     - TEST_PGI=no
     - NCHOME=/usr/
     addons:
@@ -118,7 +118,7 @@ script:
 - cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc test_atmospheres.nc
 - ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
 - ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
-- python verification.py
+- python3 verification.py
 #
 # Build library - Open-acc kernels
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -168,7 +168,6 @@ script:
 - ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
 - ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
 - python3 verification.py
-
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ install:
 
 before_script:
 - export RRTMGP_ROOT=$PWD
-- export RRTMGP_DIR=$PWD/build
+- export RRTMGP_BUILD=$PWD/build
 - export NFHOME=${HOME}/netcdff
 - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NFHOME/lib
 - cd examples/rfmip-clear-sky

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: required
 dist: xenial
 language: cpp
-# Could run both sets of kernels in parallel but setup is the majority of the time
-#env:
-#  - RTE_KERNELS=""
-#  - RTE_KERNELS="openacc"
+env:
+  - RTE_KERNELS=""
+  - RTE_KERNELS="openacc"
 matrix:
   include:
   - compiler: gcc # Using
@@ -94,52 +93,33 @@ before_script:
 - python3 ./stage_files.py
 - cd ../..
 script:
-# Build library - default kernels
+- cd ${RRTMGP_ROOT}
+#
+# Build library
+#
 - make -C build clean || exit 1
 - make -C build       || exit 1
+#
 # Build and run RFMIP examples
+#
 - cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky || exit 1
 - make clean
 - make || exit 1
 - python3 ./run-rfmip-examples.py
 - python3 ./compare-to-reference.py --fail=7.e-4
 - make clean
+#
 # Build and run all-sky example
+#
 - cd ${RRTMGP_ROOT}/examples/all-sky || exit 1
 - make clean
 - make || exit 1
 - python3 ./run-allsky-example.py
 - python3 ./compare-to-reference.py
 - make clean
-# Build and regression tests
-- cd ${RRTMGP_ROOT}/tests|| exit 1
-- make clean
-- make || exit 1
-- cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc test_atmospheres.nc
-- ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
-- ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
-- python3 verification.py
 #
-# Build library - Open-acc kernels
-#
-# Build library - default kernels
-- make -C build clean || exit 1
-- make -C build       || exit 1
-# Build and run RFMIP examples
-- cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky || exit 1
-- make clean
-- make || exit 1
-- python3 ./run-rfmip-examples.py
-- python3 ./compare-to-reference.py --fail=7.e-4
-- make clean
-# Build and run all-sky example
-- cd ${RRTMGP_ROOT}/examples/all-sky || exit 1
-- make clean
-- make || exit 1
-- python3 ./run-allsky-example.py
-- python3 ./compare-to-reference.py
-- make clean
 # Build and regression tests
+#
 - cd ${RRTMGP_ROOT}/tests|| exit 1
 - make clean
 - make || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,48 +5,52 @@ language: cpp
 #env:
 #  - RTE_KERNELS=""
 #  - RTE_KERNELS="openacc"
-include:
-- compiler: gcc # Using
-  env:
-  - FC=pgfortran
-  - FCFLAGS="-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
-  - TEST_PGI=yes
-  addons:
-    apt:
-      sources:
-        - ubuntu-toolchain-r-test
-      packages:
-        - gcc-8
-        - gfortran-8
-        - libnetcdf-dev
-- compiler: gcc
-  env:
-  - FC=gfortran-9
-  - FCFLAGS="-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
-  - TEST_PGI=no
-  - NCHOME=/usr/
-  addons:
-    apt:
-      sources:
-        - ubuntu-toolchain-r-test
-      packages:
-        - gcc-9
-        - gfortran-9
-        - libnetcdf-dev
-- compiler: gcc
-  env:
-  - FC=gfortran-8
-  - FCFLAGS="-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
-  - TEST_PGI=no
-  - NCHOME=/usr/
-  addons:
-    apt:
-      sources:
-        - ubuntu-toolchain-r-test
-      packages:
-        - gcc-8
-        - gfortran-8
-        - libnetcdf-dev
+matrix:
+  include:
+  - name: "PGI community edition "
+    compiler: gcc
+    env:
+    - FC=pgfortran
+    - FCFLAGS="-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+    - TEST_PGI=yes
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - gcc-8
+          - gfortran-8
+          - libnetcdf-dev
+  - name: "gcc-9"
+    compiler: gcc
+    env:
+    - FC=gfortran-9
+    - FCFLAGS="-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
+    - TEST_PGI=no
+    - NCHOME=/usr/
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - gcc-9
+          - gfortran-9
+          - libnetcdf-dev
+  - name: "gcc-8"
+    compiler: gcc
+    env:
+    - FC=gfortran-8
+    - FCFLAGS="-ffree-line-length-none -m64 -std=f2008 -march=native -fbounds-check -finit-real=nan -DUSE_CBOOL"
+    - TEST_PGI=no
+    - NCHOME=/usr/
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - gcc-8
+          - gfortran-8
+          - libnetcdf-dev
 # cache:
 #   timeout: 1000
 #   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,23 +95,30 @@ before_script:
 - cd ../..
 script:
 # Build library - default kernels
-- cd build || exit 1
-- make || exit 1
-- cd .. || exit 1
+- make -C build clean || exit 1
+- make -C build       || exit 1
 # Build and run RFMIP examples
-- cd examples/rfmip-clear-sky || exit 1
+- cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky || exit 1
 - make clean
 - make || exit 1
 - python3 ./run-rfmip-examples.py
 - python3 ./compare-to-reference.py --fail=7.e-4
-- cd ../..
+- make clean
 # Build and run all-sky example
-- cd examples/all-sky || exit 1
+- cd ${RRTMGP_ROOT}/examples/all-sky || exit 1
 - make clean
 - make || exit 1
 - python3 ./run-allsky-example.py
 - python3 ./compare-to-reference.py
-- cd ../..
+- make clean
+# Build and regression tests
+- cd ${RRTMGP_ROOT}/tests|| exit 1
+- make clean
+- make || exit 1
+- cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc test_atmospheres.nc
+- ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
+- ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
+- python verification.py
 #
 # Build library - Open-acc kernels
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,25 +122,31 @@ script:
 #
 # Build library - Open-acc kernels
 #
-- export RTE_KERNELS="openacc"
-- cd build || exit 1
-- make clean
-- make || exit 1
-- cd .. || exit 1
+# Build library - default kernels
+- make -C build clean || exit 1
+- make -C build       || exit 1
 # Build and run RFMIP examples
-- cd examples/rfmip-clear-sky || exit 1
+- cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky || exit 1
 - make clean
 - make || exit 1
 - python3 ./run-rfmip-examples.py
 - python3 ./compare-to-reference.py --fail=7.e-4
-- cd ../..
+- make clean
 # Build and run all-sky example
-- cd examples/all-sky || exit 1
+- cd ${RRTMGP_ROOT}/examples/all-sky || exit 1
 - make clean
 - make || exit 1
 - python3 ./run-allsky-example.py
 - python3 ./compare-to-reference.py
-- cd ../..
+- make clean
+# Build and regression tests
+- cd ${RRTMGP_ROOT}/tests|| exit 1
+- make clean
+- make || exit 1
+- cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc test_atmospheres.nc
+- ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
+- ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
+- python3 verification.py
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 sudo: required
 dist: xenial
 language: cpp
+# Could run both sets of kernels in parallel but setup is the majority of the time
+#env:
+#  - RTE_KERNELS=""
+#  - RTE_KERNELS="openacc"
 matrix:
   include:
-  - env:
-    - RTE_KERNELS=""
-    - RTE_KERNELS="openacc"
   - compiler: gcc # Using
     env:
     - FC=pgfortran
@@ -93,6 +94,9 @@ before_script:
 - python3 ./stage_files.py
 - cd ../..
 script:
+#
+# Default kernels
+#
 - cd ${RRTMGP_ROOT}
 #
 # Build library
@@ -127,6 +131,44 @@ script:
 - ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
 - ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
 - python3 verification.py
+#
+# Open-acc kernels
+#
+- cd ${RRTMGP_ROOT}
+#
+# Build library
+#
+- make -C build clean || exit 1
+- make -C build       || exit 1
+#
+# Build and run RFMIP examples
+#
+- cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky || exit 1
+- make clean
+- make || exit 1
+- python3 ./run-rfmip-examples.py
+- python3 ./compare-to-reference.py --fail=7.e-4
+- make clean
+#
+# Build and run all-sky example
+#
+- cd ${RRTMGP_ROOT}/examples/all-sky || exit 1
+- make clean
+- make || exit 1
+- python3 ./run-allsky-example.py
+- python3 ./compare-to-reference.py
+- make clean
+#
+# Build and regression tests
+#
+- cd ${RRTMGP_ROOT}/tests|| exit 1
+- make clean
+- make || exit 1
+- cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc test_atmospheres.nc
+- ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
+- ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
+- python3 verification.py
+
 notifications:
   email:
     on_success: never

--- a/Contibuting.md
+++ b/Contibuting.md
@@ -1,0 +1,19 @@
+### Contributing to RTE+RRTMGP
+
+Thanks for considering making a contribution to RTE+RRTMGP.
+
+The code in this repository is intended to work with compilers supporting the Fortran 2008 standard. It is also expected to run end-to-end on GPUs when compiled with OpenACC. Commits are tested with [Travis](https://travis-ci.com) against gfortran versions 8 and 9 and against various versions > 19.9 of the PGI compiler using resources provided by the [Swiss Supercomputing Center](https://cscs.ch). The testing uses two general codes in `examples/`for which results are compared against existing implemetations,  and custom codes in tests/ intended to excercise all code options.
+
+##### Did you find a bug? 
+
+Please file an issue on the [Github page](https://github.com/RobertPincus/rte-rrtmgp/issues). 
+
+##### Did you write a patch that fixes a bug?
+
+Please fork this repository, branch from `develop`, make your changes, and open a Github [pull request](https://github.com/RobertPincus/rte-rrtmgp/pulls) against branch `develop`. 
+
+##### Did you add functionality? 
+
+Please fork this repository, branch from `develop`, make your changes, and open a Github [pull request](https://github.com/RobertPincus/rte-rrtmgp/pulls) against branch `develop`,  adding a new regression test or comparison against the reference in `tests/verification.py` or `tests/validation-plots.py` as appropriate.  
+
+RTE+RRTMGP is intended to be a core that users can extend with custom code to suit their own needs. 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,6 +80,8 @@ jobs:
       export FC=ftn
       make -C build/ clean
       make -C build/ -j 8
+      make -C tests clean
+      make -C tests -j 8
       make -C examples/all-sky clean
       make -C examples/all-sky -j 8
       make -C examples/rfmip-clear-sky clean
@@ -88,20 +90,23 @@ jobs:
   - script: |
       set -e
       source modules
-      cd examples/rfmip-clear-sky
+      cd $(RRTMGP_ROOT)/examples/rfmip-clear-sky
       srun -C gpu -A c15 -p cscsci python ./run-rfmip-examples.py --block_size 1800
-      cd ../..
-      cd examples/all-sky
+      cd  $(RRTMGP_ROOT)/examples/all-sky
       srun -C gpu -A c15 -p cscsci python ./run-allsky-example.py
+      cd  $(RRTMGP_ROOT)/tests
+      srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
+      srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
     displayName: 'Run'
   - script: |
       set -e
       source modules
       # This module will unload some of the build modules, so do the checks separately
       module load netcdf-python
-      cd examples/rfmip-clear-sky
+      cd $(RRTMGP_ROOT)/examples/rfmip-clear-sky
       python ./compare-to-reference.py --fail=7.e-4
-      cd ../..
-      cd examples/all-sky
+      cd $(RRTMGP_ROOT)/examples/all-sky
       python ./compare-to-reference.py
+      cd $(RRTMGP_ROOT)/tests
+      python verification.py
     displayName: 'Check results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
       set -e
       source modules
       export RRTMGP_ROOT=$PWD
-      export RRTMGP_DIR=$PWD/build
+      export RRTMGP_BUILD=$PWD/build
       export FC=ftn
       make -C build/ clean
       make -C build/ -j 8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,7 +81,7 @@ jobs:
       make -C build/ clean
       make -C build/ -j 8
       make -C tests clean
-      make -C tests -j 1
+      make -C tests -j 8
       make -C examples/all-sky clean
       make -C examples/all-sky -j 8
       make -C examples/rfmip-clear-sky clean
@@ -90,6 +90,8 @@ jobs:
   - script: |
       set -e
       source modules
+      export RRTMGP_ROOT=$PWD
+      export RRTMGP_BUILD=$PWD/build
       cd $(RRTMGP_ROOT)/examples/rfmip-clear-sky
       srun -C gpu -A c15 -p cscsci python ./run-rfmip-examples.py --block_size 1800
       cd  $(RRTMGP_ROOT)/examples/all-sky
@@ -101,6 +103,8 @@ jobs:
   - script: |
       set -e
       source modules
+      export RRTMGP_ROOT=$PWD
+      export RRTMGP_BUILD=$PWD/build
       # This module will unload some of the build modules, so do the checks separately
       module load netcdf-python
       cd $(RRTMGP_ROOT)/examples/rfmip-clear-sky

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,11 +92,12 @@ jobs:
       source modules
       export RRTMGP_ROOT=$PWD
       export RRTMGP_BUILD=$PWD/build
-      cd $RRTMGP_ROOT/examples/rfmip-clear-sky
+      cd ${RRTMGP_BUILD}/examples/rfmip-clear-sky
       srun -C gpu -A c15 -p cscsci python ./run-rfmip-examples.py --block_size 1800
-      cd  $RRTMGP_ROOT/examples/all-sky
+      cd  ${RRTMGP_BUILD}/examples/all-sky
       srun -C gpu -A c15 -p cscsci python ./run-allsky-example.py
-      cd  $RRTMGP_ROOT/tests
+      cd  ${RRTMGP_BUILD}/tests
+      cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc test_atmospheres.nc
       srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
       srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
     displayName: 'Run'
@@ -107,10 +108,10 @@ jobs:
       export RRTMGP_BUILD=$PWD/build
       # This module will unload some of the build modules, so do the checks separately
       module load netcdf-python
-      cd $RRTMGP_ROOT/examples/rfmip-clear-sky
+      cd ${RRTMGP_BUILD}/examples/rfmip-clear-sky
       python ./compare-to-reference.py --fail=7.e-4
-      cd $RRTMGP_ROOT/examples/all-sky
+      cd ${RRTMGP_BUILD}/examples/all-sky
       python ./compare-to-reference.py
-      cd $RRTMGP_ROOT/tests
+      cd ${RRTMGP_BUILD}/tests
       python verification.py
     displayName: 'Check results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ jobs:
         accel_module: cudatoolkit
         FCFLAGS: "-O3 -ta=tesla:cc60,cuda10.1 -Mallocatable=03 -gopt -Minline,reshape,maxsize:40"
         RTE_KERNELS: openacc
+        RUN_CMD: "srun -C gpu -A c15 -p cscsci"
       pgi_default_gpu:
         compiler_module: pgi
         PrgEnv: PrgEnv-pgi
@@ -16,18 +17,21 @@ jobs:
         # Generic accelerator flag
         FCFLAGS: "-O3 -acc                   -Mallocatable=03 -gopt"
         RTE_KERNELS: openacc
+        RUN_CMD: "srun -C gpu -A c15 -p cscsci"
       pgi_19_10_cpu:
         compiler_module: PGI/19.10
         PrgEnv: PrgEnv-pgi
         accel_module:
         # Error checking flags
         FCFLAGS: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+        RUN_CMD:
       pgi_19_9_cpu:
         compiler_module: PGI/19.9
         PrgEnv: PrgEnv-pgi
         accel_module:
         # Error checking flags
         FCFLAGS: "-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+        RUN_CMD:
       pgi_default_cpu:
         compiler_module: pgi
         PrgEnv: PrgEnv-pgi
@@ -92,13 +96,13 @@ jobs:
       source modules
       export RRTMGP_ROOT=$PWD
       cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky
-      srun -C gpu -A c15 -p cscsci python ./run-rfmip-examples.py --block_size 1800
+      python ./run-rfmip-examples.py --block_size 1800
       cd  ${RRTMGP_ROOT}/examples/all-sky
-      srun -C gpu -A c15 -p cscsci python ./run-allsky-example.py
+      ${RUN_CMD} python ./run-allsky-example.py
       cd  ${RRTMGP_ROOT}/tests
       cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc test_atmospheres.nc
-      srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
-      srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
+      ${RUN_CMD} ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
+      ${RUN_CMD} ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
     displayName: 'Run'
   - script: |
       set -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
       source modules
       export RRTMGP_ROOT=$PWD
       cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky
-      python ./run-rfmip-examples.py --block_size 1800
+      srun -C gpu -A c15 -p cscsci python ./run-rfmip-examples.py --block_size 1800
       cd  ${RRTMGP_ROOT}/examples/all-sky
       srun -C gpu -A c15 -p cscsci python ./run-allsky-example.py
       cd  ${RRTMGP_ROOT}/tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,6 @@ jobs:
         accel_module: cudatoolkit
         FCFLAGS: "-O3 -ta=tesla:cc60,cuda10.1 -Mallocatable=03 -gopt -Minline,reshape,maxsize:40"
         RTE_KERNELS: openacc
-        RUN_CMD: "srun -C gpu -A c15 -p cscsci"
       pgi_default_gpu:
         compiler_module: pgi
         PrgEnv: PrgEnv-pgi
@@ -17,7 +16,6 @@ jobs:
         # Generic accelerator flag
         FCFLAGS: "-O3 -acc                   -Mallocatable=03 -gopt"
         RTE_KERNELS: openacc
-        RUN_CMD: "srun -C gpu -A c15 -p cscsci"
       pgi_19_10_cpu:
         compiler_module: PGI/19.10
         PrgEnv: PrgEnv-pgi
@@ -98,11 +96,11 @@ jobs:
       cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky
       python ./run-rfmip-examples.py --block_size 1800
       cd  ${RRTMGP_ROOT}/examples/all-sky
-      ${RUN_CMD} python ./run-allsky-example.py
+      srun -C gpu -A c15 -p cscsci python ./run-allsky-example.py
       cd  ${RRTMGP_ROOT}/tests
       cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc test_atmospheres.nc
-      ${RUN_CMD} ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
-      ${RUN_CMD} ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
+      srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
+      srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
     displayName: 'Run'
   - script: |
       set -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,11 +92,11 @@ jobs:
       source modules
       export RRTMGP_ROOT=$PWD
       export RRTMGP_BUILD=$PWD/build
-      cd $(RRTMGP_ROOT)/examples/rfmip-clear-sky
+      cd $RRTMGP_ROOT/examples/rfmip-clear-sky
       srun -C gpu -A c15 -p cscsci python ./run-rfmip-examples.py --block_size 1800
-      cd  $(RRTMGP_ROOT)/examples/all-sky
+      cd  $RRTMGP_ROOT/examples/all-sky
       srun -C gpu -A c15 -p cscsci python ./run-allsky-example.py
-      cd  $(RRTMGP_ROOT)/tests
+      cd  $RRTMGP_ROO/tests
       srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
       srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
     displayName: 'Run'
@@ -107,10 +107,10 @@ jobs:
       export RRTMGP_BUILD=$PWD/build
       # This module will unload some of the build modules, so do the checks separately
       module load netcdf-python
-      cd $(RRTMGP_ROOT)/examples/rfmip-clear-sky
+      cd $RRTMGP_ROOT/examples/rfmip-clear-sky
       python ./compare-to-reference.py --fail=7.e-4
-      cd $(RRTMGP_ROOT)/examples/all-sky
+      cd $RRTMGP_ROOT/examples/all-sky
       python ./compare-to-reference.py
-      cd $(RRTMGP_ROOT)/tests
+      cd $RRTMGP_ROOT/tests
       python verification.py
     displayName: 'Check results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,7 +81,7 @@ jobs:
       make -C build/ clean
       make -C build/ -j 8
       make -C tests clean
-      make -C tests -j 8
+      make -C tests -j 1
       make -C examples/all-sky clean
       make -C examples/all-sky -j 8
       make -C examples/rfmip-clear-sky clean

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
       srun -C gpu -A c15 -p cscsci python ./run-rfmip-examples.py --block_size 1800
       cd  $RRTMGP_ROOT/examples/all-sky
       srun -C gpu -A c15 -p cscsci python ./run-allsky-example.py
-      cd  $RRTMGP_ROO/tests
+      cd  $RRTMGP_ROOT/tests
       srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
       srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
     displayName: 'Run'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,12 +91,11 @@ jobs:
       set -e
       source modules
       export RRTMGP_ROOT=$PWD
-      export RRTMGP_BUILD=$PWD/build
-      cd ${RRTMGP_BUILD}/examples/rfmip-clear-sky
+      cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky
       srun -C gpu -A c15 -p cscsci python ./run-rfmip-examples.py --block_size 1800
-      cd  ${RRTMGP_BUILD}/examples/all-sky
+      cd  ${RRTMGP_ROOT}/examples/all-sky
       srun -C gpu -A c15 -p cscsci python ./run-allsky-example.py
-      cd  ${RRTMGP_BUILD}/tests
+      cd  ${RRTMGP_ROOT}/tests
       cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc test_atmospheres.nc
       srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
       srun -C gpu -A c15 -p cscsci ./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
@@ -105,13 +104,12 @@ jobs:
       set -e
       source modules
       export RRTMGP_ROOT=$PWD
-      export RRTMGP_BUILD=$PWD/build
       # This module will unload some of the build modules, so do the checks separately
       module load netcdf-python
-      cd ${RRTMGP_BUILD}/examples/rfmip-clear-sky
+      cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky
       python ./compare-to-reference.py --fail=7.e-4
-      cd ${RRTMGP_BUILD}/examples/all-sky
+      cd ${RRTMGP_ROOT}/examples/all-sky
       python ./compare-to-reference.py
-      cd ${RRTMGP_BUILD}/tests
+      cd ${RRTMGP_ROOT}/tests
       python verification.py
     displayName: 'Check results'

--- a/build/Makefile.conf.ifort
+++ b/build/Makefile.conf.ifort
@@ -8,11 +8,11 @@ export FC = ifort
 #
 # Optimized
 #
-export FCFLAGS  += -m64 -O3 -g -traceback -assume realloc_lhs -extend-source 132
+export FCFLAGS  += -m64 -O3 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132
 export F77FLAGS += -m64 -O3 -g -traceback
 # can add  -qopt-report-phase=vec
 #
 # Debugging
 #
-# export FCFLAGS  = -m64 -g  -traceback -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f03
+# export FCFLAGS  = -m64 -g  -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
 # export F77FLAGS = -m64 -g  -traceback                                        -check bounds,uninit,pointers,stack

--- a/examples/all-sky/run-allsky-example.py
+++ b/examples/all-sky/run-allsky-example.py
@@ -9,7 +9,7 @@ import glob
 import argparse
 
 rte_rrtmgp_dir   = os.path.join("..", "..")
-# This files lives in $RRTMGP_DIR/examples/all-sky/
+# This files lives in $RRTMGP_ROOT/examples/all-sky/
 all_sky_dir      = "."
 # Code should be run in the all_sky_dir directory
 

--- a/examples/rfmip-clear-sky/Makefile
+++ b/examples/rfmip-clear-sky/Makefile
@@ -1,15 +1,15 @@
 #
-# Here set variables RRTMGP_DIR, NCHOME, NFHOME, TIME_DIR (for GPTL)
+# Here set variables RRTMGP_BUILD, NCHOME, NFHOME, TIME_DIR (for GPTL)
 #   or have those variables set in the environment
 #
 -include Makefile.libs
--include $(RRTMGP_DIR)/Makefile.conf
+-include $(RRTMGP_BUILD)/Makefile.conf
 #
 # RRTMGP library, module files
 #
-LDFLAGS   += -L$(RRTMGP_DIR)
+LDFLAGS   += -L$(RRTMGP_BUILD)
 LIBS      += -lrrtmgp -lrte
-FCINCLUDE += -I$(RRTMGP_DIR)
+FCINCLUDE += -I$(RRTMGP_BUILD)
 
 #
 # netcdf library, module files
@@ -53,11 +53,11 @@ ADDITIONS = mo_simple_netcdf.o mo_rfmip_io.o mo_load_coefficients.o
 
 all: rrtmgp_rfmip_lw rrtmgp_rfmip_sw
 
-rrtmgp_rfmip_lw:   rrtmgp_rfmip_lw.o   $(ADDITIONS) $(RRTMGP_DIR)/librte.a $(RRTMGP_DIR)/librrtmgp.a
+rrtmgp_rfmip_lw:   rrtmgp_rfmip_lw.o   $(ADDITIONS) $(RRTMGP_BUILD)/librte.a $(RRTMGP_BUILD)/librrtmgp.a
 
 rrtmgp_rfmip_lw.o: rrtmgp_rfmip_lw.F90 $(ADDITIONS)
 
-rrtmgp_rfmip_sw:   rrtmgp_rfmip_sw.o   $(ADDITIONS) $(RRTMGP_DIR)/librte.a $(RRTMGP_DIR)/librrtmgp.a
+rrtmgp_rfmip_sw:   rrtmgp_rfmip_sw.o   $(ADDITIONS) $(RRTMGP_BUILD)/librte.a $(RRTMGP_BUILD)/librrtmgp.a
 
 rrtmgp_rfmip_sw.o: rrtmgp_rfmip_sw.F90 $(ADDITIONS)
 

--- a/examples/rfmip-clear-sky/Makefile.libs.macos
+++ b/examples/rfmip-clear-sky/Makefile.libs.macos
@@ -1,5 +1,5 @@
 # Location of RTE+RRTMGP libraries, module files.
-export RRTMGP_DIR = ../../build
+export RRTMGP_BUILD = ../../build
 # Sets macros FC, FCFLAGS consistent with RTE+RRTMGP
 
 # NetCDF C and Fortran libraries, module files

--- a/examples/rfmip-clear-sky/Makefile.libs.olcf
+++ b/examples/rfmip-clear-sky/Makefile.libs.olcf
@@ -1,5 +1,5 @@
 # Location of RTE+RRTMGP libraries, module files.
-export RRTMGP_DIR = ../../build
+export RRTMGP_BUILD = ../../build
 # Sets macros FC, FCFLAGS consistent with RTE+RRTMGP
 
 # NetCDF C and Fortran libraries, module files
@@ -7,4 +7,4 @@ NCHOME = $(OLCF_NETCDF_ROOT)
 NFHOME = $(OLCF_NETCDF_FORTRAN_ROOT)
 
 # GPTL libraries and module files if desired (https://jmrosinski.github.io/GPTL/)
-# export TIME_DIR 
+# export TIME_DIR

--- a/rte/kernels-openacc/mo_rte_solver_kernels.F90
+++ b/rte/kernels-openacc/mo_rte_solver_kernels.F90
@@ -1397,10 +1397,10 @@ contains
     real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: ssa  ! single-scattering albedo,
     real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: g       ! asymmetry parameter []
     real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lay_source   ! Planck source at layer average temperature [W/m2]
-    real(wp), dimension(ncol,nlay+1,ngpt), intent(in   ) :: lev_source_inc
+    real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lev_source_inc
                                         ! Planck source at layer edge for radiation in increasing ilay direction [W/m2]
                                         ! Includes spectral weighting that accounts for state-dependent frequency to g-space mapping
-    real(wp), dimension(ncol,nlay+1,ngpt), intent(in   ) :: lev_source_dec
+    real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lev_source_dec
                                                ! Planck source at layer edge for radiation in decreasing ilay direction [W/m2]
     real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_emis     ! Surface emissivity      []
     real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_src      ! Surface source function [W/m2]

--- a/rte/kernels/mo_rte_solver_kernels.F90
+++ b/rte/kernels/mo_rte_solver_kernels.F90
@@ -1114,10 +1114,10 @@ subroutine lw_solver_1rescl_GaussQuad(ncol, nlay, ngpt, top_at_1, nmus, Ds, weig
   real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: ssa  ! single-scattering albedo,
   real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: g       ! asymmetry parameter []
   real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lay_source   ! Planck source at layer average temperature [W/m2]
-  real(wp), dimension(ncol,nlay+1,ngpt), intent(in   ) :: lev_source_inc
+  real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lev_source_inc
                                       ! Planck source at layer edge for radiation in increasing ilay direction [W/m2]
                                       ! Includes spectral weighting that accounts for state-dependent frequency to g-space mapping
-  real(wp), dimension(ncol,nlay+1,ngpt), intent(in   ) :: lev_source_dec
+  real(wp), dimension(ncol,nlay,  ngpt), intent(in   ) :: lev_source_dec
                                              ! Planck source at layer edge for radiation in decreasing ilay direction [W/m2]
   real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_emis     ! Surface emissivity      []
   real(wp), dimension(ncol,       ngpt), intent(in   ) :: sfc_src      ! Surface source function [W/m2]

--- a/rte/mo_optical_props.F90
+++ b/rte/mo_optical_props.F90
@@ -809,13 +809,15 @@ contains
     integer :: ncol, nlay, ngpt, nmom
     ! -----
     err_message = ""
-    if(.not. op_in%bands_are_equal(op_io)) then
-      err_message = "ty_optical_props%increment: optical properties objects have different band structures"
-      return
-    end if
     ncol = op_io%get_ncol()
     nlay = op_io%get_nlay()
     ngpt = op_io%get_ngpt()
+    if(.not. op_in%bands_are_equal(op_io)) &
+      err_message = "ty_optical_props%increment: optical properties objects have different band structures"
+    if(.not. all([op_in%get_ncol(), op_in%get_nlay()] == [ncol, nlay])) &
+      err_message = "ty_optical_props%increment: optical properties objects have different ncol and/or nlay"
+    if(err_message /= "")  return
+    
     if(op_in%gpoints_are_equal(op_io)) then
       !
       ! Increment by gpoint

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,66 @@
+# Location of RTE+RRTMGP libraries, module files.
+RRTMGP_BUILD = $(RRTMGP_ROOT)/build
+# Sets macros FC, FCFLAGS consistent with RTE+RRTMGP
+-include $(RRTMGP_BUILD)/Makefile.conf
+
+# Location of netcdf C and Fortran libraries. Could specify with environment variables if file doesn't exist
+-include $(RRTMGP_ROOT)/examples/rfmip-clear-sky/Makefile.libs
+#
+# RRTMGP library, module files
+#
+LDFLAGS   += -L$(RRTMGP_BUILD)
+LIBS      += -lrrtmgp -lrte
+FCINCLUDE += -I$(RRTMGP_BUILD)
+
+#
+# netcdf library, module files
+# C and Fortran interfaces respectively
+#
+FCINCLUDE += -I$(NFHOME)/include
+LDFLAGS   += -L$(NFHOME)/lib -L$(NCHOME)/lib
+LIBS      += -lnetcdff -lnetcdf
+
+VPATH  = .:$(RRTMGP_ROOT)/examples:$(RRTMGP_ROOT)/examples/rfmip-clear-sky
+VPATH += $(RRTMGP_ROOT)/extensions:$(RRTMGP_ROOT)/extensions/cloud_optics:$(RRTMGP_ROOT)/extensions/solar_variability
+
+# Compilation rules
+%.o: %.F90
+	$(FC) $(FCFLAGS) $(FCINCLUDE) -c $<
+%: %.o
+	$(FC) $(FCFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+
+#
+# Extra sources -- extensions to RRTMGP classes, shared infrastructure, local sources
+#
+ADDITIONS  = mo_heating_rates.o mo_compute_bc.o mo_rrtmgp_clr_all_sky.o
+# File I/O
+ADDITIONS += mo_load_coefficients.o mo_simple_netcdf.o mo_rfmip_io.o
+ADDITIONS += mo_testing_io.o
+# Cloud optics
+CLOUDS    += mo_cloud_sampling.o mo_cloud_optics.o mo_load_cloud_coefficients.o
+# Solar variability
+ADDITIONS += mo_solar_variability.o
+
+# Many codes will need to be updated if the library changes
+LIB_DEPS = $(RRTMGP_BUILD)/librte.a $(RRTMGP_BUILD)/librrtmgp.a
+#
+# Targets
+#
+all: clear_sky_regression
+
+clear_sky_regression:   $(ADDITIONS) $(LIB_DEPS) clear_sky_regression.o
+clear_sky_regression.o: $(ADDITIONS) $(LIB_DEPS) clear_sky_regression.F90
+
+mo_testing_io.o:        $(LIB_DEPS) mo_simple_netcdf.o mo_testing_io.F90
+
+mo_cloud_optics.o:            $(LIB_DEPS) mo_cloud_optics.F90
+mo_load_cloud_coefficients.o: $(LIB_DEPS) mo_simple_netcdf.o mo_cloud_optics.o mo_load_cloud_coefficients.F90
+mo_cloud_sampling.o:          $(LIB_DEPS) mo_cloud_sampling.F90
+
+mo_load_coefficients.o: $(LIB_DEPS) mo_simple_netcdf.o mo_load_coefficients.F90
+mo_rfmip_io.o.o:        $(LIB_DEPS) mo_simple_netcdf.o mo_rfmip_io.F90
+mo_simple_netcdf.o:     $(LIB_DEPS) mo_simple_netcdf.F90
+
+clean:
+	-rm clear_sky_regression *.o *.optrpt

--- a/tests/clear_sky_regression.F90
+++ b/tests/clear_sky_regression.F90
@@ -425,25 +425,22 @@ contains
   ! Clear-sky longwave fluxes, all info, three angles
   !   Two variations on a scattering calculation but using purely emitting/absorbing layers
   !   The first uses rescaling and should agree with _1scl answers
-  !   The second is a two-stream ve
+  !   The second uses the two-stream solver
   !
   subroutine lw_clear_sky_2str
-    type(ty_optical_props_2str) :: atmos2
     call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
                                        t_lay, sfc_t, &
                                        gas_concs,    &
                                        atmos,        &
                                        lw_sources,   &
                                        tlev=t_lev))
-    ! baustelle  - this is failing because tau == 0
-    if(.false.) then
-      call stop_on_err(rte_lw(atmos, top_at_1, &
-                              lw_sources,      &
-                              sfc_emis,        &
-                              fluxes))
-      call write_broadband_field(input_file, flux_up, "lw_flux_up_1rescl", "LW flux up, clear-sky _1rescl")
-      call write_broadband_field(input_file, flux_dn, "lw_flux_dn_1rescl", "LW flux dn, clear-sky _1rescl")
-    end if
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes))
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_1rescl", "LW flux up, clear-sky _1rescl")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_1rescl", "LW flux dn, clear-sky _1rescl")
+
     call stop_on_err(rte_lw(atmos, top_at_1, &
                             lw_sources,      &
                             sfc_emis,        &

--- a/tests/clear_sky_regression.F90
+++ b/tests/clear_sky_regression.F90
@@ -490,7 +490,6 @@ contains
     atmos_2str%tau(:,:,:) = 0._wp
     atmos_2str%ssa(:,:,:) = 0._wp
     atmos_2str%g  (:,:,:) = 0._wp
-
     !
     ! Add a transparent 2-stream atmosphere to no-scattering
     !
@@ -505,24 +504,20 @@ contains
     !
     ! Create a transparent set of n-stream optical properties
     !
-    call stop_on_err(atmos_nstr%alloc_nstr(ncol, nlay, nmom, k_dist))
+    call stop_on_err(atmos_nstr%alloc_nstr(nmom, ncol, nlay, k_dist))
     atmos_nstr%tau(:,:,:)   = 0._wp
     atmos_nstr%ssa(:,:,:)   = 0._wp
     atmos_nstr%p  (:,:,:,:) = 0._wp
-
-    ! baustelle - this is crashing for reasons I don't understand
-    if(.false.) then
-      !
-      ! Add a transparent n-stream atmosphere to no-scattering
-      !
-      call stop_on_err(atmos_nstr%increment(atmos))
-      call stop_on_err(rte_lw(atmos, top_at_1, &
-                              lw_sources,      &
-                              sfc_emis,        &
-                              fluxes))
-      call write_broadband_field(input_file, flux_up, "lw_flux_up_inc_1scl_with_nstr", "LW flux up, incr. 1scl with nstr")
-      call write_broadband_field(input_file, flux_dn, "lw_flux_dn_inc_1scl_with_nstr", "LW flux dn, incr. 1scl with nstr")
-    end if
+    !
+    ! Add a transparent n-stream atmosphere to no-scattering
+    !
+    call stop_on_err(atmos_nstr%increment(atmos))
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes))
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_inc_1scl_with_nstr", "LW flux up, incr. 1scl with nstr")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_inc_1scl_with_nstr", "LW flux dn, incr. 1scl with nstr")
 
   end subroutine lw_clear_sky_incr
   ! ----------------------------------------------------------------------------

--- a/tests/clear_sky_regression.F90
+++ b/tests/clear_sky_regression.F90
@@ -1,0 +1,735 @@
+subroutine stop_on_err(error_msg)
+  use iso_fortran_env, only : error_unit
+  character(len=*), intent(in) :: error_msg
+
+  if(error_msg /= "") then
+    write (error_unit,*) trim(error_msg)
+    write (error_unit,*) "clear-sky regression tests stopping"
+    error stop 1
+  end if
+end subroutine stop_on_err
+! ----------------------------------------------------------------------------------
+program rte_clear_sky_regression
+  use mo_rte_kind,           only: wp
+  use mo_optical_props,      only: ty_optical_props, &
+                                   ty_optical_props_arry, &
+                                  ty_optical_props_1scl, ty_optical_props_2str, ty_optical_props_nstr
+  use mo_gas_optics_rrtmgp,  only: ty_gas_optics_rrtmgp
+  use mo_gas_concentrations, only: ty_gas_concs
+  use mo_source_functions,   only: ty_source_func_lw
+  use mo_fluxes,             only: ty_fluxes_broadband
+  use mo_rte_lw,             only: rte_lw
+  use mo_rte_sw,             only: rte_sw
+  use mo_load_coefficients,  only: load_and_init
+  use mo_rfmip_io,           only: read_size, read_and_block_pt, read_and_block_gases_ty,  &
+                                   read_and_block_lw_bc, read_and_block_sw_bc, determine_gas_names
+  use mo_simple_netcdf,      only: get_dim_size, read_field
+  use mo_heating_rates,      only: compute_heating_rate
+  use mo_testing_io,         only: write_broadband_field
+  implicit none
+  ! ----------------------------------------------------------------------------------
+  ! Variables
+  ! ----------------------------------------------------------------------------------
+  ! Arrays: dimensions (col, lay, exp), as read from RFMIP test cases
+  real(wp), dimension(:,:,:), allocatable :: p_lay_3d, t_lay_3d, p_lev_3d
+  real(wp), dimension(:,:,:), allocatable :: t_lev_3d
+  real(wp), dimension(:,:),   allocatable :: sfc_t_3d
+  real(wp), dimension(:,:),   allocatable :: bc_3d, tsi_3d  ! boundary conditions (ncol, nexp)
+  real(wp), dimension(:,:),   allocatable :: sza ! Solar zenith angle (ncol, nexp)
+
+  !
+  ! Local versions of variables - used
+  !
+  real(wp), dimension(:,:),     allocatable :: p_lay, t_lay, p_lev
+  !
+  ! Longwave only
+  !
+  real(wp), dimension(:,:),   allocatable :: t_lev
+  real(wp), dimension(:),     allocatable :: sfc_t
+  real(wp), dimension(:,:),   allocatable :: sfc_emis ! First dimension is band
+  !
+  ! Shortwave only
+  !
+  real(wp), dimension(:),    allocatable :: mu0 ! solar zenith angle, cosine of same
+  real(wp), dimension(:,:),  allocatable :: sfc_alb_dir, sfc_alb_dif ! First dimension is band
+  logical,  dimension(:),    allocatable :: sun_up
+  !
+  ! Source functions
+  !
+  !   Longwave
+  type(ty_source_func_lw)               :: lw_sources
+  !   Shortwave
+  real(wp), dimension(:,:), allocatable :: toa_flux
+  !
+  ! Output variables
+  !
+  real(wp), dimension(:,:), target, &
+                            allocatable :: flux_up, flux_dn, flux_dir
+  !
+  ! Derived types from the RTE and RRTMGP libraries
+  !
+  type(ty_gas_optics_rrtmgp) :: k_dist
+  type(ty_gas_concs)         :: gas_concs
+  type(ty_gas_concs), dimension(:), allocatable &
+                             :: gas_conc_array
+  class(ty_optical_props_arry), &
+                 allocatable :: atmos
+  type(ty_fluxes_broadband)  :: fluxes
+
+  !
+  ! Inputs to RRTMGP
+  !
+  logical :: top_at_1, is_sw, is_lw
+
+  integer  :: ncol, nlay, nbnd, ngpt, nexp
+  integer  :: icol, ilay, ibnd, iloop, igas
+
+  integer  :: nUserArgs=0
+
+  character(len=32 ), &
+            dimension(:), allocatable :: kdist_gas_names, rfmip_gas_games
+
+  character(len=256) :: input_file, k_dist_file
+  ! ----------------------------------------------------------------------------------
+  ! Code
+  ! ----------------------------------------------------------------------------------
+  !
+  ! Parse command line for any file names, block size
+  !
+  nUserArgs = command_argument_count()
+  if (nUserArgs <  2) call stop_on_err("Need to supply input_file k_distribution_file")
+  if (nUserArgs >= 1) call get_command_argument(1,input_file)
+  if (nUserArgs >= 2) call get_command_argument(2,k_dist_file)
+  if (nUserArgs >  3) print *, "Ignoring command line arguments beyond the first three..."
+  if(trim(input_file) == '-h' .or. trim(input_file) == "--help") then
+    call stop_on_err("clear_sky_regression input_file absorption_coefficients_file")
+  end if
+  !
+  ! Read temperature, pressure, gas concentrations.
+  !   Arrays are allocated as they are read
+  !
+  call read_size(input_file, ncol, nlay, nexp)
+  call determine_gas_names(input_file, k_dist_file, 1, kdist_gas_names, rfmip_gas_games)
+  call read_and_block_pt(input_file, ncol, p_lay_3d, p_lev_3d, t_lay_3d, t_lev_3d)
+  !
+  ! Only do the first RFMIP experiment
+  !
+  allocate(p_lay(ncol, nlay), p_lev(ncol, nlay+1), &
+           t_lay(ncol, nlay), t_lev(ncol, nlay+1))
+  p_lay(:,:) = p_lay_3d(:,:,1)
+  p_lev(:,:) = p_lev_3d(:,:,1)
+  t_lay(:,:) = t_lay_3d(:,:,1)
+  t_lev(:,:) = t_lev_3d(:,:,1)
+  deallocate(p_lay_3d, p_lev_3d, t_lay_3d, t_lev_3d)
+  !
+  ! Read the gas concentrations and surface properties
+  !   RFMIP I/O returns an array, we're going to use first ncol values = experiement 1 (present-day)
+  !
+  call read_and_block_gases_ty(input_file, ncol*nexp, kdist_gas_names, rfmip_gas_games, gas_conc_array)
+  !
+  ! All the profiles are in the first and only element of the array of gas concentration types
+  !   Extract the first ncol profiles (this is part of testing)
+  !
+  call stop_on_err(gas_conc_array(1)%get_subset(1, ncol, gas_concs))
+  call gas_conc_array(1)%reset()
+  deallocate(gas_conc_array)
+  ! ----------------------------------------------------------------------------
+  ! load data into classes
+  call load_and_init(k_dist, k_dist_file, gas_concs)
+  is_sw = k_dist%source_is_external()
+  is_lw = .not. is_sw
+  print *, "k-distribution is for the " // merge("longwave ", "shortwave", is_lw)
+  print *, "  pressure    limits (Pa):", k_dist%get_press_min(), k_dist%get_press_max()
+  print *, "  temperature limits (Pa):", k_dist%get_temp_min(),  k_dist%get_temp_max()
+  !
+  ! Problem sizes
+  !
+  nbnd = k_dist%get_nband()
+  ngpt = k_dist%get_ngpt()
+  !
+  ! RRTMGP won't run with pressure less than its minimum. The top level in the RFMIP file
+  !   is set to 10^-3 Pa. Here we pretend the layer is just a bit less deep.
+  !
+  top_at_1 = p_lay(1, 1) < p_lay(1, nlay)
+  if(top_at_1) then
+    p_lev(:,1) = k_dist%get_press_min() + epsilon(k_dist%get_press_min())
+  else
+    p_lev(:,nlay+1) &
+                 = k_dist%get_press_min() + epsilon(k_dist%get_press_min())
+  end if
+  ! ----------------------------------------------------------------------------
+  !
+  !  Boundary conditions
+  !
+  if(is_sw) then
+    allocate(toa_flux(ncol, ngpt))
+    allocate(sfc_alb_dir(nbnd, ncol), sfc_alb_dif(nbnd, ncol), &
+             mu0(ncol), sun_up(ncol))
+    call read_and_block_sw_bc(input_file, ncol, &
+                              bc_3d, tsi_3d, sza)
+    !
+    ! Surface albedo is spectrally uniform
+    !
+    sfc_alb_dir(:,:) = spread(bc_3d(:,1), dim=1, ncopies=nbnd)
+    sfc_alb_dif(:,:) = sfc_alb_dir(:,:)
+    sun_up(:) = sza(:,1) < 87.5_wp ! Limits is from LBLRTM
+    mu0(:) = merge(cos(sza(:,1) * acos(-1._wp)/180._wp), &
+                   1._wp,                                &
+                   sun_up)
+  else
+    allocate(sfc_t(ncol), sfc_emis(nbnd, ncol))
+    call stop_on_err(lw_sources%alloc(ncol, nlay, k_dist))
+    call read_and_block_lw_bc(input_file, ncol, bc_3d, sfc_t_3d)
+    !
+    ! Surface emissivity is spectrally uniform
+    !
+    sfc_emis(:,:) = spread(bc_3d(:,1), dim=1, ncopies=nbnd)
+
+    sfc_t   (:)   = sfc_t_3d(:,1)
+  end if
+  ! ----------------------------------------------------------------------------
+  !
+  ! Fluxes
+  !
+  allocate(flux_up(ncol,nlay+1), flux_dn(ncol,nlay+1), flux_dir(ncol,nlay+1))
+  ! ----------------------------------------------------------------------------
+  !
+  ! Solvers
+  !
+  fluxes%flux_up => flux_up(:,:)
+  fluxes%flux_dn => flux_dn(:,:)
+  if(is_lw) then
+    call make_optical_props_1scl
+    call atmos%set_name("gas only atmosphere")
+    call lw_clear_sky_default
+    call lw_clear_sky_notlev
+    call lw_clear_sky_3ang
+    call lw_clear_sky_jaco
+    call lw_clear_sky_subset
+    call lw_clear_sky_vr
+    call lw_clear_sky_incr
+    call make_optical_props_2str
+    call lw_clear_sky_2str
+  else
+    call make_optical_props_2str
+    call sw_clear_sky_default
+    call sw_clear_sky_tsi
+    call sw_clear_sky_vr
+  end if
+contains
+  ! ----------------------------------------------------------------------------
+  !
+  ! Clear-sky longwave fluxes,
+  !
+  subroutine lw_clear_sky_default
+    real(wp), dimension(ncol, nlay+1), target :: flux_net
+    real(wp), dimension(ncol, nlay)           :: heating_rate
+
+    fluxes%flux_net => flux_net
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay, sfc_t, &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       lw_sources,   &
+                                       tlev = t_lev))
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes))
+    call write_broadband_field(input_file, flux_up,  "lw_flux_up",  "LW flux up")
+    call write_broadband_field(input_file, flux_dn,  "lw_flux_dn",  "LW flux dn")
+    call write_broadband_field(input_file, flux_net, "lw_flux_net", "LW flux net")
+
+    call stop_on_err(compute_heating_rate(flux_up, flux_dn, p_lev, heating_rate))
+    call write_broadband_field(input_file, heating_rate,  &
+                                                     "lw_flux_hr_default",  "LW heating rate", vert_dim_name = "layer")
+    !
+    ! Test for mo_fluxes_broadband for computing only net flux
+    !
+    nullify(fluxes%flux_up)
+    nullify(fluxes%flux_dn)
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes))
+    call write_broadband_field(input_file, flux_net, "lw_flux_net_2", "LW flux net, direct")
+    fluxes%flux_up => flux_up
+    fluxes%flux_dn => flux_dn
+    nullify(fluxes%flux_net)
+
+  end subroutine lw_clear_sky_default
+  ! ----------------------------------------------------------------------------
+  !
+  ! Clear-sky longwave fluxes, level temperatures provided
+  !
+  subroutine lw_clear_sky_notlev
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay, sfc_t, &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       lw_sources))
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes))
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_notlev", "LW flux up, no level temperatures")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_notlev", "LW flux dn, no level temperatures")
+  end subroutine lw_clear_sky_notlev
+  ! ----------------------------------------------------------------------------
+  !
+  ! Clear-sky longwave fluxes, all info, three angles
+  !
+  subroutine lw_clear_sky_3ang
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay, sfc_t, &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       lw_sources,   &
+                                       tlev = t_lev))
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes, n_gauss_angles=3))
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_3ang", "LW flux up, three quadrature angles")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_3ang", "LW flux dn, three quadrature angles")
+  end subroutine lw_clear_sky_3ang
+  ! ----------------------------------------------------------------------------
+  !
+  ! Clear-sky longwave fluxes, all info, computing surface Jacobian
+  !
+  subroutine lw_clear_sky_jaco
+    real(wp), dimension(ncol,nlay+1) :: jFluxUp
+
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay, sfc_t, &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       lw_sources,   &
+                                       tlev=t_lev))
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes,          &
+                            flux_up_Jac = jFluxUp))
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_jaco", "LW flux up, computing Jaobians")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_jaco", "LW flux dn, computing Jaobians")
+    call write_broadband_field(input_file, jFluxUp, "lw_jaco_up"     , "Jacobian of LW flux up to surface temperature")
+
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay, sfc_t + 1._wp, &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       lw_sources,   &
+                                       tlev=t_lev))
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes))
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_stp1", "LW flux up, surface T+1K")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_stp1", "LW flux dn, surface T+1K")
+  end subroutine lw_clear_sky_jaco
+  ! ----------------------------------------------------------------------------
+  !
+  ! Clear-sky longwave fluxes, half the columns at a time
+  !   We're counting on ncol being even
+  !
+  subroutine lw_clear_sky_subset
+    type(ty_optical_props_1scl) :: atmos_subset
+    type(ty_source_func_lw)     :: sources_subset
+    type(ty_fluxes_broadband)   :: fluxes ! Use local variable
+    real(wp), dimension(ncol/2, nlay+1), target &
+                                :: up, dn
+    integer :: i, colS, colE
+
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay, sfc_t, &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       lw_sources, &
+                                       tlev=t_lev))
+    ! Testing init, then alloc for 1scl
+    call stop_on_err(atmos_subset%init(atmos))
+    fluxes%flux_up => up
+    fluxes%flux_dn => dn
+    do i = 1, 2
+      colS = ((i-1) * ncol/2) + 1
+      colE = i * ncol/2
+      call stop_on_err(atmos%get_subset     (colS, ncol/2, atmos_subset))
+      call stop_on_err(lw_sources%get_subset(colS, ncol/2, sources_subset))
+      call stop_on_err(rte_lw(atmos_subset, top_at_1, &
+                              sources_subset,         &
+                              sfc_emis(:, colS:colE), &
+                              fluxes))
+      flux_up(colS:colE,:) = up
+      flux_dn(colS:colE,:) = dn
+    end do
+
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_subset", "LW flux up, done in two parts")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_subset", "LW flux dn, done in two parts")
+  end subroutine lw_clear_sky_subset
+  ! ----------------------------------------------------------------------------
+  !
+  ! Clear-sky longwave fluxes, all info, three angles
+  !   Reverse orientation in the vertical, compute, un-reverse
+  !
+  subroutine lw_clear_sky_vr
+    type(ty_gas_concs) :: gas_concs_vr
+    integer            :: i
+    real(wp), dimension(ncol,nlay) :: vmr
+    character(32), &
+              dimension(gas_concs%get_num_gases()) &
+                                  :: gc_gas_names
+    !
+    ! Reverse the orientation of the problem
+    !
+    p_lay  (:,:) = p_lay  (:, nlay   :1:-1)
+    t_lay  (:,:) = t_lay  (:, nlay   :1:-1)
+    p_lev  (:,:) = p_lev  (:,(nlay+1):1:-1)
+    t_lev  (:,:) = t_lev  (:,(nlay+1):1:-1)
+    top_at_1 = .not. top_at_1
+    !
+    ! No direct access to gas concentrations so use the classes
+    !   This also tests otherwise uncovered routines for ty_gas_concs
+    !
+    gc_gas_names(:) = gas_concs%get_gas_names()
+    call stop_on_err(gas_concs_vr%init(gc_gas_names(:)))
+    do i = 1, gas_concs%get_num_gases()
+      call stop_on_err(gas_concs%get_vmr(gc_gas_names(i), vmr))
+      vmr(:,:)  = vmr(:,nlay:1:-1)
+      call stop_on_err(gas_concs_vr%set_vmr(gc_gas_names(i), vmr))
+    end do
+
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay, sfc_t, &
+                                       gas_concs_vr, &
+                                       atmos,        &
+                                       lw_sources,   &
+                                       tlev=t_lev))
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes))
+    flux_up(:,:) = flux_up(:,(nlay+1):1:-1)
+    flux_dn(:,:) = flux_dn(:,(nlay+1):1:-1)
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_vr", "LW flux up, vertically-reversed")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_vr", "LW flux dn, vertically-reversed")
+
+    p_lay  (:,:) = p_lay  (:, nlay   :1:-1)
+    t_lay  (:,:) = t_lay  (:, nlay   :1:-1)
+    p_lev  (:,:) = p_lev  (:,(nlay+1):1:-1)
+    t_lev  (:,:) = t_lev  (:,(nlay+1):1:-1)
+    top_at_1 = .not. top_at_1
+  end subroutine lw_clear_sky_vr
+  ! ----------------------------------------------------------------------------
+  !
+  ! Clear-sky longwave fluxes, all info, three angles
+  !   Two variations on a scattering calculation but using purely emitting/absorbing layers
+  !   The first uses rescaling and should agree with _1scl answers
+  !   The second is a two-stream ve
+  !
+  subroutine lw_clear_sky_2str
+    type(ty_optical_props_2str) :: atmos2
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay, sfc_t, &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       lw_sources,   &
+                                       tlev=t_lev))
+    ! baustelle  - this is failing because tau == 0
+    if(.false.) then
+      call stop_on_err(rte_lw(atmos, top_at_1, &
+                              lw_sources,      &
+                              sfc_emis,        &
+                              fluxes))
+      call write_broadband_field(input_file, flux_up, "lw_flux_up_1rescl", "LW flux up, clear-sky _1rescl")
+      call write_broadband_field(input_file, flux_dn, "lw_flux_dn_1rescl", "LW flux dn, clear-sky _1rescl")
+    end if
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes, use_2stream=.true.))
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_2str", "LW flux up, clear-sky _2str")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_2str", "LW flux dn, clear-sky _2str")
+
+  end subroutine lw_clear_sky_2str
+  ! ----------------------------------------------------------------------------
+  !
+  ! Tests for incrementing optical properties
+  !
+  subroutine lw_clear_sky_incr
+    type(ty_optical_props_1scl) :: atmos2
+    type(ty_optical_props_2str) :: atmos_2str
+    type(ty_optical_props_nstr) :: atmos_nstr
+    integer, parameter          :: nmom = 4
+
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay, sfc_t, &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       lw_sources,   &
+                                       tlev = t_lev))
+
+    ! Two sets of optical properties, each with half the original optical
+    !   depth, should produce the same fluxes
+    call stop_on_err(atmos2%alloc_1scl(ncol, nlay, atmos))
+    atmos%tau (:,:,:) = atmos%tau(:,:,:) * 0.5_wp
+    atmos2%tau(:,:,:) = atmos%tau(:,:,:)
+    call stop_on_err(atmos2%increment(atmos))
+
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes))
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_inc_1scl_with_1scl", "LW flux up, incr. 1scl with 1scl")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_inc_1scl_with_1scl", "LW flux dn, incr. 1scl with 1scl")
+
+    !
+    ! Create a transparent set of 2-stream optical properties
+    !
+    call stop_on_err(atmos_2str%alloc_2str(ncol, nlay, k_dist))
+    atmos_2str%tau(:,:,:) = 0._wp
+    atmos_2str%ssa(:,:,:) = 0._wp
+    atmos_2str%g  (:,:,:) = 0._wp
+
+    !
+    ! Add a transparent 2-stream atmosphere to no-scattering
+    !
+    call stop_on_err(atmos_2str%increment(atmos))
+    call stop_on_err(rte_lw(atmos, top_at_1, &
+                            lw_sources,      &
+                            sfc_emis,        &
+                            fluxes))
+    call write_broadband_field(input_file, flux_up, "lw_flux_up_inc_1scl_with_2str", "LW flux up, incr. 1scl with 2str")
+    call write_broadband_field(input_file, flux_dn, "lw_flux_dn_inc_1scl_with_2str", "LW flux dn, incr. 1scl with 2str")
+
+    !
+    ! Create a transparent set of n-stream optical properties
+    !
+    call stop_on_err(atmos_nstr%alloc_nstr(ncol, nlay, nmom, k_dist))
+    atmos_nstr%tau(:,:,:)   = 0._wp
+    atmos_nstr%ssa(:,:,:)   = 0._wp
+    atmos_nstr%p  (:,:,:,:) = 0._wp
+
+    ! baustelle - this is crashing for reasons I don't understand
+    if(.false.) then
+      !
+      ! Add a transparent n-stream atmosphere to no-scattering
+      !
+      call stop_on_err(atmos_nstr%increment(atmos))
+      call stop_on_err(rte_lw(atmos, top_at_1, &
+                              lw_sources,      &
+                              sfc_emis,        &
+                              fluxes))
+      call write_broadband_field(input_file, flux_up, "lw_flux_up_inc_1scl_with_nstr", "LW flux up, incr. 1scl with nstr")
+      call write_broadband_field(input_file, flux_dn, "lw_flux_dn_inc_1scl_with_nstr", "LW flux dn, incr. 1scl with nstr")
+    end if
+
+  end subroutine lw_clear_sky_incr
+  ! ----------------------------------------------------------------------------
+  !
+  ! Shortwave tests
+  !
+  ! ----------------------------------------------------------------------------
+  !
+  ! Shortwave - default
+  !
+  subroutine sw_clear_sky_default
+    real(wp), dimension(ncol, ngpt) :: rfmip_tsi_scale
+    real(wp)                        :: rrtmgp_tsi
+    type(ty_optical_props_2str)     :: atmos2
+
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay,        &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       toa_flux))
+    !
+    ! Scaling factor for column dependence of TSI in RFMIP
+    !
+    rrtmgp_tsi = sum(toa_flux(1,:))
+    rfmip_tsi_scale(:,:) = spread(tsi_3d(:,1)/rrtmgp_tsi, dim=2, ncopies=ngpt)
+    toa_flux(:,:) = toa_flux(:,:) * rfmip_tsi_scale(:,:)
+
+    call stop_on_err(rte_sw(atmos, top_at_1, &
+                            mu0,   toa_flux, &
+                            sfc_alb_dir, sfc_alb_dif, &
+                            fluxes))
+    !
+    ! Fluxes were computed for all columns; here mask where sun is down
+    !
+    where(spread(.not. sun_up, dim=2, ncopies=nlay+1))
+      flux_up  = 0._wp
+      flux_dn  = 0._wp
+    end where
+    call write_broadband_field(input_file, flux_up,  "sw_flux_up",  "SW flux up")
+    call write_broadband_field(input_file, flux_dn,  "sw_flux_dn",  "SW flux dn")
+
+    !
+    ! Two sets of optical properties, each with half the original optical
+    !   depth, should produce the same fluxes
+    !
+    call stop_on_err(atmos2%alloc_2str(ncol, nlay, atmos))
+    atmos%tau(:,:,:)  = atmos%tau(:,:,:) * 0.5_wp
+    atmos2%tau(:,:,:) = atmos%tau(:,:,:)
+    select type(atmos)
+      class is (ty_optical_props_2str)
+        atmos2%ssa(:,:,:) = atmos%ssa(:,:,:)
+        atmos2%g  (:,:,:) = atmos%g  (:,:,:)
+      class default
+        call stop_on_err("rte_rrtmgp_atmos: Don't recognize the kind of optical properties ")
+    end select
+    call stop_on_err(atmos2%increment(atmos))
+    call stop_on_err(rte_sw(atmos, top_at_1, &
+                            mu0,   toa_flux, &
+                            sfc_alb_dir, sfc_alb_dif, &
+                            fluxes))
+    where(spread(.not. sun_up, dim=2, ncopies=nlay+1))
+      flux_up  = 0._wp
+      flux_dn  = 0._wp
+    end where
+    call write_broadband_field(input_file, flux_up,  "sw_flux_up_incr",  "SW flux up, incr. 2str with 2str")
+    call write_broadband_field(input_file, flux_dn,  "sw_flux_dn_incr",  "SW flux dn, incr. 2str with 2str")
+  end subroutine sw_clear_sky_default
+  ! ----------------------------------------------------------------------------
+  !
+  ! Shortwave - Set the total solar irradiance
+  !
+  subroutine sw_clear_sky_tsi
+    real(wp), dimension(ncol, ngpt) :: rfmip_tsi_scale
+    real(wp)                        :: rrtmgp_tsi
+    real(wp), parameter             :: tsi_scale = 0.5_wp
+
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay,        &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       toa_flux))
+    !
+    ! Scaling factor for column dependence of TSI in RFMIP
+    !
+    rrtmgp_tsi = sum(toa_flux(1,:))
+    rfmip_tsi_scale(:,:) = spread(tsi_3d(:,1)/rrtmgp_tsi, dim=2, ncopies=ngpt)
+
+    ! Set TSI to half the default
+    call stop_on_err(k_dist%set_tsi(tsi_scale*rrtmgp_tsi))
+    ! Redo gas optics
+    call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                       t_lay,        &
+                                       gas_concs,    &
+                                       atmos,        &
+                                       toa_flux))
+    toa_flux(:,:) = toa_flux(:,:) * rfmip_tsi_scale(:,:)
+    call stop_on_err(rte_sw(atmos, top_at_1, &
+                            mu0,   toa_flux, &
+                            sfc_alb_dir, sfc_alb_dif, &
+                            fluxes))
+    !
+    ! Fluxes were computed for all columns; here mask where sun is down
+    !
+    where(spread(.not. sun_up, dim=2, ncopies=nlay+1))
+      flux_up  = 0._wp
+      flux_dn  = 0._wp
+    end where
+    call write_broadband_field(input_file, flux_up /tsi_scale, "sw_flux_up_tsi",  "SW flux up, reset TSI")
+    call write_broadband_field(input_file, flux_dn /tsi_scale, "sw_flux_dn_tsi",  "SW flux dn, reset TSI")
+
+    call stop_on_err(k_dist%set_tsi(2.0_wp * sum(toa_flux(1,:))))
+  end subroutine sw_clear_sky_tsi
+  ! ----------------------------------------------------------------------------
+  !
+  ! Shortwave - vertically reversed
+  !
+  subroutine sw_clear_sky_vr
+    real(wp), dimension(ncol, ngpt) :: rfmip_tsi_scale
+    real(wp)                        :: rrtmgp_tsi
+    type(ty_gas_concs) :: gas_concs_vr
+    integer            :: i
+    real(wp), dimension(ncol,nlay) :: vmr
+    character(32), &
+              dimension(gas_concs%get_num_gases()) &
+                                  :: gc_gas_names
+
+  !
+  ! Reverse the orientation of the problem
+  !
+  p_lay  (:,:) = p_lay  (:, nlay   :1:-1)
+  t_lay  (:,:) = t_lay  (:, nlay   :1:-1)
+  p_lev  (:,:) = p_lev  (:,(nlay+1):1:-1)
+  top_at_1 = .not. top_at_1
+  !
+  ! No direct access to gas concentrations so use the classes
+  !   This also tests otherwise uncovered routines for ty_gas_concs
+  !
+  gc_gas_names(:) = gas_concs%get_gas_names()
+  call stop_on_err(gas_concs_vr%init(gc_gas_names(:)))
+  do i = 1, gas_concs%get_num_gases()
+    call stop_on_err(gas_concs%get_vmr(gc_gas_names(i), vmr))
+    vmr(:,:)  = vmr(:,nlay:1:-1)
+    call stop_on_err(gas_concs_vr%set_vmr(gc_gas_names(i), vmr))
+  end do
+
+  call stop_on_err(k_dist%gas_optics(p_lay, p_lev, &
+                                     t_lay,        &
+                                     gas_concs_vr, &
+                                     atmos,        &
+                                     toa_flux))
+  !
+  ! Scaling factor for column dependence of TSI in RFMIP
+  !
+  rrtmgp_tsi = sum(toa_flux(1,:))
+  rfmip_tsi_scale(:,:) = spread(tsi_3d(:,1)/rrtmgp_tsi, dim=2, ncopies=ngpt)
+  toa_flux(:,:) = toa_flux(:,:) * rfmip_tsi_scale(:,:)
+
+  call stop_on_err(rte_sw(atmos, top_at_1, &
+                          mu0,   toa_flux, &
+                          sfc_alb_dir, sfc_alb_dif, &
+                          fluxes))
+  !
+  ! Fluxes were computed for all columns; here mask where sun is down
+  !
+  where(spread(.not. sun_up, dim=2, ncopies=nlay+1))
+    flux_up  = 0._wp
+    flux_dn  = 0._wp
+  end where
+  flux_up (:,:) = flux_up (:,(nlay+1):1:-1)
+  flux_dn (:,:) = flux_dn (:,(nlay+1):1:-1)
+  call write_broadband_field(input_file, flux_up,  "sw_flux_up_vr",  "SW flux up, vertically-reversed")
+  call write_broadband_field(input_file, flux_dn,  "sw_flux_dn_vr",  "SW flux dn, vertically-reversed")
+
+  p_lay  (:,:) = p_lay  (:, nlay   :1:-1)
+  t_lay  (:,:) = t_lay  (:, nlay   :1:-1)
+  p_lev  (:,:) = p_lev  (:,(nlay+1):1:-1)
+  top_at_1 = .not. top_at_1
+end subroutine sw_clear_sky_vr
+  ! ----------------------------------------------------------------------------
+  subroutine make_optical_props_1scl
+    if(allocated(atmos )) deallocate(atmos)
+    allocate(ty_optical_props_1scl::atmos)
+    ! Clouds optical props are defined by band
+    !
+    ! Allocate arrays for the optical properties themselves.
+    !
+    select type(atmos)
+      class is (ty_optical_props_1scl)
+        call stop_on_err(atmos%alloc_1scl(ncol, nlay, k_dist))
+      class default
+        call stop_on_err("rte_rrtmgp_atmos: Don't recognize the kind of optical properties ")
+    end select
+  end subroutine make_optical_props_1scl
+  ! ----------------------------------------------------------------------------
+  subroutine make_optical_props_2str
+    if(allocated(atmos )) deallocate(atmos)
+    allocate(ty_optical_props_2str::atmos)
+    ! Clouds optical props are defined by band
+    !
+    ! Allocate arrays for the optical properties themselves.
+    !
+    select type(atmos)
+      class is (ty_optical_props_2str)
+        call stop_on_err(atmos%alloc_2str(ncol, nlay, k_dist))
+      class default
+        call stop_on_err("rte_rrtmgp_atmos: Don't recognize the kind of optical properties ")
+    end select
+  end subroutine make_optical_props_2str
+  ! ----------------------------------------------------------------------------
+end program rte_clear_sky_regression

--- a/tests/intel-codecov.sh
+++ b/tests/intel-codecov.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+ulimit -s hard
+export FC=ifort
+export FCFLAGS="-m64 -prof-gen=srcpos -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132"
+#
+# Intel specific - where will the profiling files be generated?
+#
+export RRTMGP_ROOT=`cd ..;pwd`
+export RRTMGP_BUILD=${RRTMGP_ROOT}/build
+export PROF_DIR=$PWD
+#
+# Environment variables for netCDF Fortran and C installations
+#
+export NFHOME=${HOME}/Applications/${FC}
+export NCHOME=/opt/local
+
+#
+# An Anaconda environent with modules needed for other python scripts
+#   (xarray, matplotlib, ...)
+#
+source activate pangeo
+cd ${PROF_DIR}
+rm -rf *.dyn pgopti.* CODE_COVERAGE.html CodeCoverage/
+#
+# Build RTE+RRTMGP librarues
+#
+make -C ${RRTMGP_BUILD} clean
+make -C ${RRTMGP_BUILD} -j 4 || exit 1
+
+#
+# Build and run RFMIP examples
+#
+cd ${RRTMGP_ROOT}/examples/rfmip-clear-sky || exit 1
+export FCFLAGS+=" -I${RRTMGP_BUILD} -I${NFHOME}/include"
+export LDFLAGS+=" -L${RRTMGP_BUILD} -L${NFHOME}/lib -L${NCHOME}/lib -lrte -lrrtmgp -lnetcdff -lnetcdf"
+make clean || exit 1
+make -j 4  || exit 1
+python ./stage_files.py
+python ./run-rfmip-examples.py
+python ./compare-to-reference.py --fail=7.e-4
+make clean
+#
+# Build and run all-sky examples
+#
+cd ${RRTMGP_ROOT}/examples/all-sky || exit 1
+make clean || exit 1
+make -j 4  || exit 1
+python ./run-allsky-example.py
+python ./compare-to-reference.py
+make clean
+#
+# Build and run regression tests
+#
+cd ${PROF_DIR} || exit 1
+make clean || exit 1
+make -j 4  || exit 1
+cp ${RRTMGP_ROOT}/examples/rfmip-clear-sky/multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc test_atmospheres.nc
+./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
+./clear_sky_regression test_atmospheres.nc ${RRTMGP_ROOT}/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
+# Need to repeat for openacc-kernels
+
+#
+# Merge
+#
+cd ${PROF_DIR}
+profmerge -a
+echo "
+mo_
+~mo_simple_netcdf
+~mo_rfmip_io
+~mo_testing_io
+~mo_garand_atmos_io
+~mo_load" > intel_codecov_filter.txt
+codecov -prj rte-rrtmgp -comp intel_codecov_filter.txt
+rm intel_codecov_filter.txt

--- a/tests/mo_testing_io.F90
+++ b/tests/mo_testing_io.F90
@@ -1,0 +1,60 @@
+!--------------------------------------------------------------------------------------------------------------------
+module mo_testing_io
+  !
+  ! RTE+RRTMGP modules
+  !
+  use mo_rte_kind,           only: wp
+  !
+  ! NetCDF I/O routines, shared with other RTE+RRTMGP examples
+  !
+  use mo_simple_netcdf,      only: write_field, create_dim, create_var
+  use netcdf
+  implicit none
+  private
+  public :: write_broadband_field
+contains
+  !--------------------------------------------------------------------------------------------------------------------
+  subroutine write_broadband_field(fileName, field, field_name, field_description, col_dim_name, vert_dim_name)
+    !
+    ! Write a field defined by column and some vertical dimension (lev or lay))
+    !
+    character(len=*),         intent(in) :: fileName
+    real(wp), dimension(:,:), intent(in) :: field
+    character(len=*),         intent(in) :: field_name, field_description
+    character(len=*), optional, &
+                              intent(in) ::col_dim_name, vert_dim_name
+    ! -------------------
+    integer           :: ncid, varid, ncol, nlev
+    !
+    ! Names of column (first) and vertical (second) dimension.
+    !   Because they are used in an array constuctor the need to have the same number of characters
+    !
+    character(len=32) :: cdim, vdim
+    ! -------------------
+    cdim = "site "
+    vdim = "level"
+    if(present(col_dim_name))  cdim = col_dim_name
+    if(present(vert_dim_name)) vdim = vert_dim_name
+
+    if(nf90_open(trim(fileName), NF90_WRITE, ncid) /= NF90_NOERR) &
+      call stop_on_err("write_fluxes: can't open file " // trim(fileName))
+
+    ncol  = size(field, dim=1)
+    nlev  = size(field, dim=2)
+
+    call create_dim(ncid, trim(cdim), ncol)
+    call create_var(ncid, trim(field_name),  [cdim, vdim], [ncol, nlev])
+    call stop_on_err(write_field(ncid, trim(field_name),  field))
+    !
+    ! Adding descriptive text as an attribute means knowing the varid
+    !
+    if(nf90_inq_varid(ncid, trim(field_name), varid) /= NF90_NOERR) &
+      call stop_on_err("Can't find variable " // trim(field_name))
+    if(nf90_put_att(ncid, varid, "description", trim(field_description)) /= NF90_NOERR) &
+      call stop_on_err("Can't write 'description' attribute to variable " // trim(field_name))
+
+    ncid = nf90_close(ncid)
+
+  end subroutine write_broadband_field
+  !--------------------------------------------------------------------------------------------------------------------
+end module mo_testing_io

--- a/tests/validation-plots.py
+++ b/tests/validation-plots.py
@@ -1,0 +1,150 @@
+import numpy as np
+import xarray as xr
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+import seaborn as sb
+import colorcet as cc
+
+def mae(diff, col_dim):
+    #
+    # Mean absolute error
+    #
+    return(xr.ufuncs.fabs(diff).mean(dim=col_dim))
+def rms(diff, col_dim):
+    #
+    # Root mean square error
+    #
+    return(xr.ufuncs.sqrt(xr.ufuncs.square(diff).mean(dim=col_dim)))
+
+def make_comparison_plot(variants, labels, reference, vscale, col_dim="site", lay_dim="layer"):
+    #
+    # Make a plot comparing differences with respect to reference
+    #
+    if type(variants) is not list:
+        make_comparison_plot([variants], [labels], reference, vscale)
+    else:
+        for i in np.arange(0, len(variants)):
+            delta = variants[i] - reference
+            plt.plot(mae(delta, col_dim),
+                     vscale, '-',\
+                     color=cols[i], label=labels[i])
+            plt.plot(rms(delta, col_dim),
+                     vscale, '--',\
+                     color=cols[i])
+        # Reverse vertical ordering
+        plt.legend()
+        # Reverse vertical ordering
+        plt.ylim(vscale.max(), vscale.min())
+
+def construct_lbl_esgf_name(var):
+    #
+    # For a given variable name, provide the OpenDAP URL for the LBLRM line-by-line results
+    #
+    prefix = "http://esgf3.dkrz.de/thredds/dodsC/cmip6/RFMIP/AER/LBLRTM-12-8/rad-irf/r1i1p1f1/Efx/"
+    return(prefix + var + "/gn/v20190514/" + var + "_Efx_LBLRTM-12-8_rad-irf_r1i1p1f1_gn.nc")
+
+########################################################################
+if __name__ == '__main__':
+    gp = xr.open_dataset("test_atmospheres.nc")
+    #
+    # Does the flux plus the Jacobian equal a calculation with perturbed surface temperature?
+    #
+    gp['lw_flux_up_from_deriv'] = gp.lw_flux_up  + gp.lw_jaco_up
+    gp.lw_flux_up_from_deriv.attrs = {"description":"LW flux up, surface T+1K, computed from Jacobian"}
+    lbl = xr.open_mfdataset([construct_lbl_esgf_name(v) for v in ["rsd", "rsu", "rld", "rlu"]],
+                            combine = "by_coords").sel(expt=0)
+    ########################################################################
+    #
+    # The RFMIP cases are on an irregular pressure grid so we can't compute errors
+    #   as a function of pressure
+    # Interpolate onto a uniform pressure level - every 10 hPa
+    #   plev varies from site to site - could the interpolation be made more concise?
+    #
+    plevs = np.arange(0, lbl.plev.max(), 1000)
+    plevs[0] = lbl.plev.min().values
+    plev = xr.DataArray(plevs, dims=['plev'], coords={'plev': plevs})
+    lbli = xr.concat([lbl.sel(site=i).reset_coords().swap_dims({"level":"plev"}).interp(plev=plev) for i in np.arange(0, lbl.site.size)], dim = 'site')
+    gpi  = xr.concat([ gp.sel(site=i).rename({"pres_level":"plev"}).\
+                                      reset_coords().swap_dims({"level":"plev"}).interp(plev=plev) for i in np.arange(0,  gp.site.size)], dim = 'site')
+
+    cols = cc.glasbey_dark
+    with PdfPages('validation-figures.pdf') as pdf:
+        ########################################################################
+        # Longwave
+        ########################################################################
+        #
+        # Accuracy - 3-angle and single-angle
+        #
+        variants = [[gpi.lw_flux_dn, gpi.lw_flux_dn_3ang, gpi.lw_flux_dn_2str],
+                    [gpi.lw_flux_up, gpi.lw_flux_up_3ang, gpi.lw_flux_up_2str],
+                    [gpi.lw_flux_net,
+                    gpi.lw_flux_dn_3ang - gpi.lw_flux_up_3ang]]
+        refs = [lbli.rld,  lbli.rlu,  lbli.rld -  lbli.rlu]
+        titles = ["Accuracy wrt LBLRTM: LW down", "Accuracy wrt LBLRTM: LW up", "Accuracy: LW net"]
+        for v, r, t in zip(variants, refs, titles):
+            make_comparison_plot(v, \
+                                 labels = ["default", "3-angle", "2-stream"], \
+                                 reference = r,            \
+                                 vscale = plev/100.)
+            plt.ylabel("Pressure (Pa)")
+            plt.xlabel("Error (W/m2), solid=mean, dash=RMS")
+            plt.title(t)
+            pdf.savefig()
+            plt.close()
+
+        #
+        # Variants on the default - should be near but not precisely 0
+        #
+        # Level temperatures not provided
+        # Using scattering representations of optical properties
+        #   to do a no-scattering calculation
+        #
+        variants = [[gpi.lw_flux_dn_notlev,  gpi.lw_flux_dn_2str],
+                    [gpi.lw_flux_up_notlev,  gpi.lw_flux_up_2str]]
+        refs =     [gpi.lw_flux_dn,         gpi.lw_flux_up]
+        titles =   ["Variants: LW down",    "Variants: LW up"]
+        for v, r, t in zip(variants, refs, titles):
+            make_comparison_plot(v, \
+                                 labels = ["no-tlev", "2str"], \
+                                 reference = r,            \
+                                 vscale = plev/100.)
+            plt.ylabel("Pressure (Pa)")
+            plt.xlabel("Difference (W/m2), solid=mean, dash=RMS")
+            plt.title(t)
+            pdf.savefig()
+            plt.close()
+
+        variants = [gpi.lw_flux_up_from_deriv]
+        refs =     [gpi.lw_flux_up_stp1]
+        titles =   ["Variants: LW up"]
+        for v, r, t in zip(variants, refs, titles):
+            make_comparison_plot(v, \
+                                 labels = "Jacobian test", \
+                                 reference = r,            \
+                                 vscale = plev/100.)
+            plt.ylabel("Pressure (Pa)")
+            plt.xlabel("Difference (W/m2), solid=mean, dash=RMS")
+            plt.title(t)
+            pdf.savefig()
+            plt.close()
+        ########################################################################
+        # Shortwave
+        #   These are in W/m2 so profiles with high run count for more.
+        #   Would they be better scaled to incoming solar flux?
+        ########################################################################
+        #
+        # Accuracy comparison
+        #
+        variants = [gpi.sw_flux_dn, gpi.sw_flux_up]
+        refs =     [lbli.rsd,               lbli.rsu]
+        titles = ["Accuracy: SW down", "Accuracy: SW up"]
+        for v, r, t in zip(variants, refs, titles):
+            make_comparison_plot(v, \
+                                 labels = "default", \
+                                 reference = r, \
+                                 vscale = plev/100.)
+            plt.ylabel("Pressure (Pa)")
+            plt.xlabel("Error (W/m2), solid=mean, dash=RMS")
+            plt.title(t)
+            pdf.savefig()
+            plt.close()

--- a/tests/validation-plots.py
+++ b/tests/validation-plots.py
@@ -113,20 +113,6 @@ if __name__ == '__main__':
             plt.title(t)
             pdf.savefig()
             plt.close()
-
-        variants = [gpi.lw_flux_up_from_deriv]
-        refs =     [gpi.lw_flux_up_stp1]
-        titles =   ["Variants: LW up"]
-        for v, r, t in zip(variants, refs, titles):
-            make_comparison_plot(v, \
-                                 labels = "Jacobian test", \
-                                 reference = r,            \
-                                 vscale = plev/100.)
-            plt.ylabel("Pressure (Pa)")
-            plt.xlabel("Difference (W/m2), solid=mean, dash=RMS")
-            plt.title(t)
-            pdf.savefig()
-            plt.close()
         ########################################################################
         # Shortwave
         #   These are in W/m2 so profiles with high run count for more.
@@ -136,7 +122,7 @@ if __name__ == '__main__':
         # Accuracy comparison
         #
         variants = [gpi.sw_flux_dn, gpi.sw_flux_up]
-        refs =     [lbli.rsd,               lbli.rsu]
+        refs =     [lbli.rsd,       lbli.rsu]
         titles = ["Accuracy: SW down", "Accuracy: SW up"]
         for v, r, t in zip(variants, refs, titles):
             make_comparison_plot(v, \

--- a/tests/verification.py
+++ b/tests/verification.py
@@ -1,0 +1,72 @@
+import xarray as xr
+import argparse
+import sys
+
+def assert_equal(variants, reference):
+    #
+    # Computes difference between reference and each variant, reports if differences
+    #   exceed a threshold
+    #
+    passed = True
+    if type(variants) is not list:
+        assert_equal([variants], reference)
+    else:
+        print('Using %s as reference:'%(reference.description))
+        for v in variants:
+            diff = xr.ufuncs.fabs(v - reference)
+            print('    %s'%(v.description))
+            if diff.max() > report_threshold:
+                print('      differs from reference by as much as %e'%(diff.max()))
+            passed = passed and diff.max() <= failure_threshold
+        print('')
+    return(passed)
+
+
+########################################################################
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Compares all-sky example output to file in reference directory")
+    parser.add_argument("--report_threshold", type=float, default=1.e-10,
+                        help="Threshold for reporting differences")
+    parser.add_argument("--failure_threshold", type=float, default=1.e-5,
+                        help="Threshold at which differences cause failure")
+    args = parser.parse_args()
+    report_threshold  = args.report_threshold
+    failure_threshold = args.failure_threshold
+
+    gp = xr.open_dataset("test_atmospheres.nc")
+    ########################################################################
+    #
+    # Some variants we expect to be essentially equal to the default, so we'll check
+    #   for those
+    ###############################
+    #
+    # Longwave
+    #
+    passed = assert_equal([gp.lw_flux_dn_vr, gp.lw_flux_dn_jaco, gp.lw_flux_dn_subset], gp.lw_flux_dn)
+    passed = assert_equal([gp.lw_flux_up_vr, gp.lw_flux_up_jaco, gp.lw_flux_up_subset], gp.lw_flux_up)  and passed
+    passed = assert_equal(gp.lw_flux_net_2,  gp.lw_flux_net) and passed
+    #
+    # Does the flux plus the Jacobian equal a calculation with perturbed surface temperature?
+    #
+    gp['lw_flux_up_from_deriv'] = gp.lw_flux_up_jaco  + gp.lw_jaco_up
+    gp.lw_flux_up_from_deriv.attrs = {"description":"LW flux up, surface T+1K, computed from Jacobian"}
+    passed = assert_equal(gp.lw_flux_up_from_deriv, gp.lw_flux_up_stp1)  and passed
+    ###############################
+    #
+    # Shortwave
+    #
+    passed = assert_equal([gp.sw_flux_dn_vr, gp.sw_flux_dn_tsi], gp.sw_flux_dn) and passed
+    passed = assert_equal([gp.sw_flux_up_vr, gp.sw_flux_up_tsi], gp.sw_flux_up) and passed
+
+    print('Incrementing')
+    passed = assert_equal([gp.lw_flux_dn_inc_1scl_with_1scl, gp.lw_flux_dn_inc_1scl_with_2str], gp.lw_flux_dn) and passed
+    passed = assert_equal([gp.lw_flux_up_inc_1scl_with_1scl, gp.lw_flux_up_inc_1scl_with_2str], gp.lw_flux_up) and passed
+    # passed = assert_equal(gp.lw_flux_dn_inc_2str_with_1scl,                            gp.lw_flux_dn_2str) and passed
+    # passed = assert_equal(gp.lw_flux_up_inc_2str_with_1scl,                            gp.lw_flux_up_2str) and passed
+    passed = assert_equal([gp.sw_flux_dn_incr],
+                 gp.sw_flux_dn) and passed
+    passed = assert_equal([gp.sw_flux_up_incr],
+                 gp.sw_flux_up) and passed
+
+    if not passed: print("Something is terribly, terribly wrong")
+    sys.exit(0) if passed else sys.exit(1)

--- a/tests/verification.py
+++ b/tests/verification.py
@@ -59,8 +59,8 @@ if __name__ == '__main__':
     passed = assert_equal([gp.sw_flux_up_vr, gp.sw_flux_up_tsi], gp.sw_flux_up) and passed
 
     print('Incrementing')
-    passed = assert_equal([gp.lw_flux_dn_inc_1scl_with_1scl, gp.lw_flux_dn_inc_1scl_with_2str], gp.lw_flux_dn) and passed
-    passed = assert_equal([gp.lw_flux_up_inc_1scl_with_1scl, gp.lw_flux_up_inc_1scl_with_2str], gp.lw_flux_up) and passed
+    passed = assert_equal([gp.lw_flux_dn_inc_1scl_with_1scl, gp.lw_flux_dn_inc_1scl_with_2str, gp.lw_flux_dn_inc_1scl_with_nstr], gp.lw_flux_dn) and passed
+    passed = assert_equal([gp.lw_flux_up_inc_1scl_with_1scl, gp.lw_flux_up_inc_1scl_with_2str, gp.lw_flux_up_inc_1scl_with_nstr], gp.lw_flux_up) and passed
     # passed = assert_equal(gp.lw_flux_dn_inc_2str_with_1scl,                            gp.lw_flux_dn_2str) and passed
     # passed = assert_equal(gp.lw_flux_up_inc_2str_with_1scl,                            gp.lw_flux_up_2str) and passed
     passed = assert_equal([gp.sw_flux_dn_incr],


### PR DESCRIPTION
Adding a new 'tests/' directory for regression and validation tests. At present this does clear-sky only using the RFMIP present-day atmospheres. A single executable does the calculation in many different ways to exercise all options. A verification Python script compares results that should be identical. A validation Python script compares results to LBLRTM and makes a few plots. 