### PR TITLE
A few small cosmetic fixes

### DIFF
--- a/build/Makefile.conf.gfortran
+++ b/build/Makefile.conf.gfortran
@@ -9,9 +9,9 @@ export FC = gfortran
 #
 # Optimized
 #
-export FCFLAGS = -ffree-line-length-none -m64 -std=f2003 -march=native -O3
+export FCFLAGS = -ffree-line-length-none -m64 -std=f2003 -march=native -O3 -DUSE_CBOOL
 #
 # Debugging - -mno-avx is particular to (broken) gcc setups using MacPorts
 #
-export FCFLAGS = -ffree-line-length-none -m64 -std=f2003 -march=native -mno-avx -pedantic -g -fbounds-check -Wall -fbacktrace -finit-real=nan
-#export FCFLAGS = -ffree-line-length-none -m64 -std=f2003 -march=native          -pedantic -g -fbounds-check -Wall -fbacktrace -finit-real=nan
+#export FCFLAGS = -ffree-line-length-none -m64 -std=f2003 -march=native -mno-avx -pedantic -g -fbounds-check -Wall -fbacktrace -finit-real=nan -DUSE_CBOOL
+#export FCFLAGS = -ffree-line-length-none -m64 -std=f2003 -march=native          -pedantic -g -fbounds-check -Wall -fbacktrace -finit-real=nan -DUSE_CBOOL

--- a/examples/rfmip-clear-sky/Readme.md
+++ b/examples/rfmip-clear-sky/Readme.md
@@ -17,4 +17,4 @@ some optional arguments, see `run-rfmip-examples.py -h`
 answers produced on a Mac with Intel 19 Fortran compiler. Differences are normally
 within 10<sup>-6</sup> W/m<sup>2</sup>.
 
-The Python scripts require modules `netCDF4`, `numpy`, and `xarray`.
+The Python scripts require modules `netCDF4`, `numpy`, `xarray`, `dask`, and `toolz`.

--- a/examples/rfmip-clear-sky/Readme.md
+++ b/examples/rfmip-clear-sky/Readme.md
@@ -17,4 +17,5 @@ some optional arguments, see `run-rfmip-examples.py -h`
 answers produced on a Mac with Intel 19 Fortran compiler. Differences are normally
 within 10<sup>-6</sup> W/m<sup>2</sup>.
 
-The Python scripts require modules `netCDF4`, `numpy`, `xarray`, `dask`, and `toolz`.
+The Python scripts require modules `netCDF4`, `numpy`, `xarray`, and `dask`.
+Install with `pip` requires `pip install dask[array]` for the latter.

--- a/examples/rfmip-clear-sky/stage_files.py
+++ b/examples/rfmip-clear-sky/stage_files.py
@@ -27,8 +27,8 @@ for f in glob.glob("multiple_input4MIPs_radiation_RFMIP*.nc"): os.remove(f)
 #
 # Download the profiles for RFMIP; make the empty output files
 #
-print("Dowloading RFMIP input files")
+print("Downloading RFMIP input files")
 urllib.request.urlretrieve(conds_url,     conds_file)
-print("Dowloading scripts for generating output templates")
+print("Downloading scripts for generating output templates")
 urllib.request.urlretrieve(templ_scr_url, templ_scr)
 subprocess.run([sys.executable, templ_scr, "--source_id", "RTE-RRTMGP-181204"])


### PR DESCRIPTION
1. Make the `Makefile.conf` for gfortran use -DUSE_CBOOL by default in order make it compile with the `std=f2003` flag.
2. Corrected a typo in the output to the screen in the RFMIP test case and completed the list of required packages in the Readme.md of the example